### PR TITLE
ci: distribute prebuilt binaries through a Homebrew tap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: Build
+
+# The distributable binaries, built once and called from two places: CI runs it
+# on every pull request, the release workflow runs it when a release is
+# published. Keeping one definition is the point — when the matrix lived only in
+# the release workflow, a target that no longer compiled stayed invisible until
+# a tag was pushed, which is the most expensive moment to find out.
+#
+# Every target passes an explicit `--target`, so the arm64 macOS runner can also
+# produce the Intel macOS binary; the rest build natively on a matching runner.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: >-
+          Version string embedded in the archive names. The release workflow
+          passes the tag; CI passes a placeholder, since its archives are only
+          ever downloaded by a human checking a pull request.
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux builds run on the oldest supported runner so the binaries link
+          # against an older glibc and stay usable on distros that a newer runner
+          # image would have left behind.
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04-arm }
+          - { target: aarch64-apple-darwin, os: macos-latest }
+          # Cross-compiled from the arm64 runner rather than built on an Intel
+          # image, which is on its way out. `cc` passes `-arch x86_64` for this
+          # triple, which is all bundled SQLite needs.
+          - { target: x86_64-apple-darwin, os: macos-latest }
+          # No Windows targets. `~/.claude` is resolved through the HOME
+          # environment variable, which Windows does not set, so every default
+          # invocation would fail before it found a transcript. Shipping a
+          # binary that cannot start is worse than shipping none.
+    # The tag reaches the steps through the environment rather than being
+    # interpolated into a script, so its text can never be read as shell.
+    env:
+      TAG: ${{ inputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+      # rusqlite is built with `bundled`, so SQLite compiles from C against each
+      # runner's native toolchain — no extra setup.
+      - name: Build
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      # The archive name carries the tag and the triple so the Homebrew formula
+      # can address it by URL without consulting the releases API.
+      - name: Package
+        run: |
+          tar -C "target/${{ matrix.target }}/release" -czf \
+            "cclens-${TAG}-${{ matrix.target }}.tar.gz" cclens
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cclens-${{ matrix.target }}
+          path: cclens-*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     name: lint + format (rustfmt, clippy)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
       # Pull prebuilt toolchain/deps and push what this run builds. Pushing needs
       # the auth token; forks/PRs without the secret fall back to pull-only.
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: cclens
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -32,31 +32,54 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: cclens
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix develop -c just test
 
+  # One job per system the flake advertises, because the cache only helps the
+  # systems it actually holds: a build pushed from Linux does nothing for a mac
+  # user, who would compile from source — the exact thing the substituter in
+  # flake.nix exists to prevent. x86_64-darwin is the gap, and it stays one until
+  # this needs an Intel macOS runner badly enough to pay for the wait.
   build:
-    name: build + push package
-    runs-on: ubuntu-latest
+    name: nix build + cachix push (${{ matrix.system }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { system: x86_64-linux, os: ubuntu-latest }
+          - { system: aarch64-linux, os: ubuntu-24.04-arm }
+          - { system: aarch64-darwin, os: macos-latest }
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v17
         with:
           name: cclens
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       # Realize the package (and its cargo deps) in the Nix store so cachix-action
       # pushes them. Without this only the devShell is cached and
       # `nix run github:lambdalisue/cclens` still compiles from source.
+      # `nix build` resolves the system from the runner, so the matrix needs no
+      # flag — the `system` column only names the job.
       - run: nix build .#default
+
+  # The same matrix the release publishes, so a target that stops compiling
+  # fails here rather than at the moment a release is cut. Archives are uploaded
+  # as run artifacts, which also makes a PR build downloadable for a quick check.
+  targets:
+    name: cross-platform build
+    uses: ./.github/workflows/build.yml
+    with:
+      tag: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,54 +1,232 @@
 name: Release
 
-# Cut a release by pushing a version tag (e.g. `git tag v0.1.0 && git push --tags`).
-# Each target builds natively on its matching runner — no cross-compilation — and
-# uploads its archive to the GitHub Release for the tag.
+# Publishing a GitHub Release is what starts this: write the notes, publish, and
+# the binaries and the Homebrew tap follow. The release therefore exists before
+# its assets do — expect a few minutes with the notes up and nothing attached.
 on:
-  push:
-    tags: ["v*"]
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
+# The tag reaches every step through the environment rather than being
+# interpolated into a script, so its text can never be read as shell.
+env:
+  TAG: ${{ github.event.release.tag_name }}
+
 jobs:
+  # Shared with CI, which runs the same matrix on every pull request — see
+  # build.yml for why the definition is not duplicated here.
   build:
-    name: ${{ matrix.target }}
+    uses: ./.github/workflows/build.yml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+
+  # The tagged commit's store paths are normally in the cache already: CI built
+  # this same commit on main, and the same commit yields the same derivation. The
+  # push below is therefore usually a no-op, and it is not the point — the pin is.
+  # An ordinary main build is collectable under the cache's retention policy,
+  # which would leave `nix run github:lambdalisue/cclens/vX.Y.Z` compiling from
+  # source. It also covers a tag cut from a commit that never landed on main.
+  nix:
+    name: pin nix build (${{ matrix.system }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-24.04-arm }
-          - { target: aarch64-apple-darwin, os: macos-latest }
-          - { target: x86_64-pc-windows-msvc, os: windows-latest }
-          - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
+          - { system: x86_64-linux, os: ubuntu-latest }
+          - { system: aarch64-linux, os: ubuntu-24.04-arm }
+          - { system: aarch64-darwin, os: macos-latest }
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      # rusqlite is built with `bundled`, so SQLite compiles from C against each
-      # runner's native toolchain (cc on unix, MSVC on Windows) — no extra setup.
-      - name: Build
-        run: cargo build --release --locked
-
-      - name: Package (unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          tar -C target/release -czf \
-            "cclens-${{ github.ref_name }}-${{ matrix.target }}.tar.gz" cclens
-
-      - name: Package (windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Compress-Archive -Path target/release/cclens.exe `
-            -DestinationPath "cclens-${{ github.ref_name }}-${{ matrix.target }}.zip"
-
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
         with:
-          files: |
-            cclens-*.tar.gz
-            cclens-*.zip
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: cachix/cachix-action@v17
+        with:
+          name: cclens
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Build, push, and pin
+        run: |
+          set -euo pipefail
+          out=$(nix build .#default --print-out-paths)
+          # Pushed here rather than left to the action's post step, which runs
+          # after this one — the pin needs the path to be in the cache already.
+          cachix push cclens "$out"
+          # The pin name is per system but deliberately NOT per tag: the three
+          # systems are distinct store paths and need their own pins, while
+          # every release re-pins the same name and so becomes a new revision of
+          # it. That is what makes --keep-revisions meaningful — a tag in the
+          # name would give each pin exactly one revision and retain them all,
+          # which is the storage growth this cache cannot afford.
+          cachix pin cclens "release-${{ matrix.system }}" "$out" --keep-revisions 3
+
+  # One job owns the upload so the four builds cannot race, and so the checksums
+  # are computed from exactly the bytes that get attached.
+  release:
+    name: attach assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Checksums
+        working-directory: dist
+        run: |
+          for f in cclens-*.tar.gz; do
+            sha256sum "$f" > "$f.sha256"
+          done
+          cat ./*.sha256
+
+      # `gh release upload` only adds assets. An action that creates-or-updates
+      # the release could rewrite the notes that were just published by hand,
+      # which is the one thing this job must not touch. --clobber keeps a re-run
+      # idempotent instead of failing on an asset that is already there.
+      - name: Upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # This job never checks the source out — it only needs the artifacts —
+          # so gh has no git remote to infer the repository from and must be
+          # told explicitly.
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "$TAG" dist/* --clobber
+
+  # Pin the tap to the archives this release just published. Runs after the
+  # assets are attached so the URLs in the formula resolve the moment it lands.
+  homebrew:
+    name: update homebrew tap
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      # HOMEBREW_TAP_TOKEN is a PAT with contents:write on the tap repository —
+      # GITHUB_TOKEN is scoped to this repository and cannot push across repos.
+      #
+      # persist-credentials must stay false: the default writes the PAT into
+      # tap/.git/config, and the verification step below runs the freshly built
+      # release binary. A compromised binary (ours or a dependency's) could then
+      # read a credential that lets it rewrite the tap. The push step supplies
+      # the token on its own instead.
+      - name: Checkout tap
+        uses: actions/checkout@v7
+        with:
+          repository: lambdalisue/homebrew-cclens
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: false
+          path: tap
+
+      - name: Render formula
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          base="https://github.com/lambdalisue/cclens/releases/download/${TAG}"
+          # $1 = target triple -> the sha256 of that target's archive.
+          sha() {
+            sha256sum "dist/cclens-${TAG}-$1.tar.gz" | cut -d' ' -f1
+          }
+          mkdir -p tap/Formula
+          cat > tap/Formula/cclens.rb <<EOF
+          # Generated by the cclens release workflow. Do not edit by hand.
+          class Cclens < Formula
+            desc "A lens onto your Claude Code usage"
+            homepage "https://github.com/lambdalisue/cclens"
+            version "${version}"
+
+            on_macos do
+              on_arm do
+                url "${base}/cclens-${TAG}-aarch64-apple-darwin.tar.gz"
+                sha256 "$(sha aarch64-apple-darwin)"
+              end
+              on_intel do
+                url "${base}/cclens-${TAG}-x86_64-apple-darwin.tar.gz"
+                sha256 "$(sha x86_64-apple-darwin)"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "${base}/cclens-${TAG}-aarch64-unknown-linux-gnu.tar.gz"
+                sha256 "$(sha aarch64-unknown-linux-gnu)"
+              end
+              on_intel do
+                url "${base}/cclens-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "$(sha x86_64-unknown-linux-gnu)"
+              end
+            end
+
+            def install
+              bin.install "cclens"
+            end
+
+            test do
+              assert_match "cclens", shell_output("#{bin}/cclens --help")
+            end
+          end
+          EOF
+          cat tap/Formula/cclens.rb
+
+      # Install the rendered formula before publishing it. A URL typo, a sha256
+      # paired with the wrong triple, or a binary that will not start all reach
+      # the tap otherwise, and users are the ones who discover it. Only the
+      # Linux x86_64 archive is downloaded and installed here; the other three
+      # are rendered by the same loop but never fetched.
+      - name: Verify formula
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          set -euo pipefail
+          # Homebrew ships preinstalled on the GitHub-hosted Ubuntu image but is
+          # not on PATH there, so the known prefix stays as a fallback. Prefer
+          # PATH so a self-hosted runner that exposes brew normally just works.
+          if ! command -v brew >/dev/null; then
+            if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            else
+              echo "brew not found on PATH or at /home/linuxbrew/.linuxbrew" >&2
+              exit 1
+            fi
+          fi
+          # Homebrew refuses a loose formula file, so expose the checkout as a
+          # real tap instead of copying the formula somewhere it would go stale.
+          tap="$(brew --repository)/Library/Taps/lambdalisue/homebrew-cclens"
+          mkdir -p "$(dirname "$tap")"
+          ln -s "$PWD/tap" "$tap"
+          brew install lambdalisue/cclens/cclens
+          brew test lambdalisue/cclens/cclens
+
+      - name: Commit and push
+        working-directory: tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/cclens.rb
+          if git diff --staged --quiet; then
+            echo "formula already up to date"
+            exit 0
+          fi
+          git commit -m "cclens ${TAG}"
+          # The helper reads TAP_TOKEN from the environment when git invokes it,
+          # so the PAT reaches neither argv (a remote URL would expose it to
+          # every process on the runner) nor .git/config. The empty first value
+          # drops any helper the runner image configured.
+          #
+          # The single quotes are load-bearing: git must expand $TAP_TOKEN when
+          # it runs the helper, not this shell when it builds the argument.
+          # shellcheck disable=SC2016
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$TAP_TOKEN"; }; f' \
+              push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ run it.
 
 ## Install / build
 
+With Homebrew (macOS and Linux, Intel and arm):
+
+```sh
+brew install lambdalisue/cclens/cclens
+```
+
 With Nix (no toolchain to set up):
 
 ```sh
@@ -29,8 +35,16 @@ just build           # release binary at target/release/cclens
 ```
 
 Plain Cargo also works (`cargo build --release`) if you have a recent stable
-Rust; the flake just pins it. CI runs `nix develop -c just check` / `just test`,
-and tagged releases (`vX.Y.Z`) build native binaries for Linux/macOS/Windows.
+Rust; the flake just pins it. CI runs `nix develop -c just check` / `just test`.
+
+Publishing a GitHub Release for a `vX.Y.Z` tag builds binaries for Linux and
+macOS (x86_64 and arm64 each), attaches them to that release with `.sha256`
+files, and points the
+[`lambdalisue/homebrew-cclens`](https://github.com/lambdalisue/homebrew-cclens)
+tap at the new archives. The release is published before its assets are built,
+so the notes are visible for a few minutes with nothing attached yet. Windows is
+not supported: `~/.claude` is located through the `HOME` environment variable,
+which Windows does not set.
 
 ## Claude Code plugin
 


### PR DESCRIPTION
## Summary

- Rebuild the tag-triggered release workflow as three jobs: `build` (4 targets) → `release` (publish) → `homebrew` (update the tap).
- Add `x86_64-apple-darwin`, cross-compiled from the arm64 macOS runner. Every target now passes an explicit `--target`.
- Publish `.sha256` files alongside the archives, computed from the exact bytes that get uploaded.
- Generate and push `Formula/cclens.rb` to [`lambdalisue/homebrew-cclens`](https://github.com/lambdalisue/homebrew-cclens), verified with `brew install` / `brew test` before it is pushed.
- Document `brew install lambdalisue/cclens/cclens` and the tag-to-release flow in the README.

## Why

The workflow existed but had never run, and it could not have produced a usable Homebrew tap. Two things were wrong.

**Intel macOS was missing.** Homebrew resolves `on_intel` for Intel Macs, so a tap without `x86_64-apple-darwin` would 404 for every Intel user. Rather than build it on an Intel runner image, which is on its way out, it is cross-compiled from the arm64 runner — `cc` passes `-arch x86_64` for that triple, which is all bundled SQLite needs. Verified: the resulting binary is `Mach-O 64-bit executable x86_64`.

**Six jobs each created the release.** Every matrix leg called `softprops/action-gh-release@v2` directly, so they raced on creating the release for the tag. One job now owns publishing, which also means the checksums are computed from the collected artifacts rather than per-runner.

The tap lives in a separate repository so `brew install lambdalisue/cclens/cclens` works with no `brew tap` step. That requires `HOMEBREW_TAP_TOKEN` (a PAT with contents:write on the tap) because `GITHUB_TOKEN` is scoped to this repository and cannot push across repos.

The `homebrew` job installs the formula it just rendered before pushing it. A URL typo, a sha256 paired with the wrong triple, or a binary that will not start otherwise reaches the tap, and users are the ones who discover it. Homebrew refuses a loose formula file, so the checkout is exposed as a real tap via a symlink into `$(brew --repository)/Library/Taps`.

Linux builds run on `ubuntu-22.04` so the binaries link against an older glibc and stay usable on distros a newer runner image would have left behind.

## Also here

- **The build matrix is a reusable workflow** (`build.yml`) called by both CI and the release. Duplicating it into CI is what let a target rot unnoticed until a tag was pushed — see below.
- **The nix package is built and pushed for three systems**, not one. `flake.nix` advertises four, but CI only ever cached `x86_64-linux`, so a mac running `nix run github:lambdalisue/cclens` compiled from source — exactly what the substituter exists to prevent. `x86_64-darwin` remains uncovered.
- **A release pins its nix build** under `release-<system>` with `--keep-revisions 3`, so the last three releases stay fetchable without the cache growing without bound.
- **Action versions bumped**: checkout v4→v7, upload-artifact v4→v7, download-artifact v4→v8, install-nix-action v30→v31, cachix-action v15→v17. Every input this workflow depends on was checked against each new major.

## Why no Windows

The first draft built `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`. A throwaway `v0.0.1-test` tag showed both legs failing to compile — `write_private_tempfile` uses `std::os::unix::fs::OpenOptionsExt` unconditionally — and the investigation that followed found the real blocker underneath: `~/.claude` is located through the `HOME` environment variable (`src/cli.rs`), which Windows does not set. Every default invocation would fail before it found a transcript, and `optimize` would additionally need PATHEXT resolution to launch `claude.cmd`.

The compile error is a five-line `#[cfg(unix)]` gate, but fixing it only buys a binary that builds — not one that runs. CI is Nix-based and Linux-only, so nothing would catch the runtime failures either. Windows is therefore out of scope here, and the matrix carries a comment saying why. Supporting it properly means portable home-directory resolution, `claude` launcher resolution, and a Windows CI leg — a separate change.

## Test Plan

Verified end to end by publishing a throwaway `v0.0.1-test` release, since none of this had ever run. The tag, its release, and the tap commit were deleted afterward; the tap is back at its seed commit.

- [x] `actionlint` clean across all three workflows
- [x] `release: published` starts the run, and GitHub takes the workflow definition from the tagged commit (`main` does not have it yet)
- [x] All four legs build: `x86_64`/`aarch64` × linux/darwin. `x86_64-apple-darwin` cross-compiles from the arm64 runner and yields a real `Mach-O 64-bit executable x86_64` with bundled SQLite
- [x] `attach assets` uploads 4 archives + 4 `.sha256`
- [x] **Hand-written release notes survive the upload** — the reason `gh release upload` replaced `softprops/action-gh-release`
- [x] `update homebrew tap` renders the formula, `brew install` and `brew test` both pass on the Linux runner through the symlinked tap, and the tap commit lands
- [x] The tap push authenticates through the credential helper with `persist-credentials: false`, and the PAT never reaches the log (masked as `***`)
- [x] sha256 agrees three ways: the published `.sha256`, a recomputation from the downloaded bytes, and the value written into the formula
- [x] `pin nix build` succeeds on all three systems; the run pulled `cclens-0.1.0` straight from `cclens.cachix.org`, confirming the release-time push is normally a no-op and the pin is the actual point
- [x] CI is green on the same commit, including the new `cross-platform build` and the two added nix systems

## Known gaps

- No `LICENSE` file and no `license` field in `Cargo.toml`, so the formula has none either. `brew install` / `brew test` do not care, but `brew audit` will.
- `cclens --version` does not exist (no `version` in the clap command), which is why the formula's `test do` asserts on `--help`.
