### PR TITLE
fix(thrash): scope an episode to one session and one path

### DIFF
--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -59,8 +59,9 @@ routed (`core::scope`):
 - **Friction categories** route by concentration: a strict-majority project owns
   the category (fix in that project's config); a spread category is global (a
   cross-project habit).
-- **Thrash** routes to the project it happened in; **cd% / prompting / token
-  totals** are behavioral, hence global.
+- **Thrash** routes to the project it happened in — carried on the episode
+  itself, since an episode is scoped to one session and therefore to one project
+  (`events.md`); **cd% / prompting / token totals** are behavioral, hence global.
 
 `--scope` narrows a report to one layer: `global`, `project` (all projects), or
 `project:<slug>` (one). `doctor`, the optimize briefing, and (by default) the
@@ -76,7 +77,7 @@ ranking.
 | `overhead` | Reconcile the empirical always-on floor (min observed `ctx_start`) against the readable always-on config; the residual is the system prompt + built-in tools + MCP schemas the catalog cannot weigh (`surfaces.md`). Includes a per-project floor table (confounded by session depth — read the global figure as authoritative). |
 | `prompts` | How the user steers the session: the mix of steer / correct / question / instruct prompts (`core::prompt`, lexical heuristics), with a verdict — heavy steering suggests more autonomy, frequent correction suggests clearer upfront specs. This is a behavioral signal, not a config metric; embeddings showed prompt *topics* do not map to reusable skills, so the value is in *how* you prompt, not *what about*. |
 | `failures` | Where the work stumbles: recurring tool failures by category (`core::friction` — edit-precondition, path-not-found, blocked-by-hook, …), ranked, each with what it suggests fixing and the originating-tool split. This analyses the *work*, not the config — where the real cost is. The classifier separates fixable friction from non-actionable noise (cancelled, transient). `--scope` follows the routing above: `global` = spread categories, `project` = each project's majority-owned categories, `project:<slug>` = everything in that one project (this subsumes the old `--project` flag). Lexical heuristics. |
-| `stuck` | Bursts of rapid re-edits to one file (`core::thrash` — N+ edits within a few minutes), ranked. This isolates *where Claude got stuck and kept retrying* from healthy spread-out editing — an algorithmic signal a flat edit count cannot give. Observed: a file edited 25× in under 8 minutes. |
+| `stuck` | Bursts of rapid re-edits to one file by one session (`core::thrash` — N+ edits within a few minutes), ranked. This isolates *where Claude got stuck and kept retrying* from healthy spread-out editing — an algorithmic signal a flat edit count cannot give. Observed: a file edited 25× in under 8 minutes. The table carries the project; `--format json` adds the session id and full path, which is what makes an episode investigable. |
 
 ### Output formats — human vs machine
 

--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -22,6 +22,8 @@ identifying the configuration surface it exercises (the join key into
 | `tool_use` | `mcp_tool` / `mcp_server` / built-in tool | point event |
 | `prompt` | — (user input; raw material for skill extraction) | point event; text referenced, not stored |
 | `tool_error` | — (a failed `tool_result`) | point event; friction category in `surface_id`, a short error-text excerpt in `source`, the originating tool name in `model`, the call's target (file_path / command) in `target` |
+| `file_edit` | — (an Edit/Write target) | point event; the file's **basename** in `surface_id`, its **full path** in `target` |
+| `bash_cmd` | — (a Bash invocation) | point event; the command's leading word in `surface_id` |
 | `compaction` | — (a `compact_boundary`) | point marker, used by the context metric |
 | `permission_prompt` | `permission` | point event (friction signal) — heuristic source |
 
@@ -48,6 +50,19 @@ Two kinds carry caveats that downstream reports must honour:
   concrete instance* (the actual failing path), which a report shows directly.
   It lives only in the local store (gitignored, never committed), so the privacy
   rule — no real data in the repo — still holds.
+
+- **`file_edit`** stores the basename *and* the full path because the two answer
+  different questions. A hotspot ranking wants the basename — it is the name a
+  human recognises, and collapsing every `route.ts` into one row is the point.
+  Thrash detection wants the opposite: an episode claims *one agent kept retrying
+  this one file*, so it must distinguish two same-named files, and two sessions
+  editing one file in parallel. Keeping only the basename made those
+  indistinguishable and let `stuck` report parallel work as an agent stuck in a
+  loop. Detection therefore groups on `(session_id, path)` — the session implies
+  the project, and the path is unique within it (`core::thrash`). The deliberate
+  cost: thrash continuing across a resume or `/clear` splits into one episode per
+  session. A split under-reports a real burst; a merge invents one that never
+  happened, and the merge is what makes the report untrustworthy.
 
 Surfaces that emit no event at all — `rule`, `hook`, `claude_md` — never produce
 rows here. That is expected, not missing data; `surfaces.md` classifies them as

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -42,7 +42,7 @@ CREATE TABLE events (
     source_line          INTEGER,         -- 0-based line index in source_path; recovers the raw record (prompt text for goal-3 clustering) without storing it
     kind                 TEXT NOT NULL,   -- skill_invocation | tool_use | agent_spawn | prompt | tool_error | compaction | permission_prompt | …
     surface_kind         TEXT,            -- join key into surfaces (NULL for surfaceless kinds)
-    surface_id           TEXT,            -- for tool_error: the friction category (no surface join, surface_kind NULL)
+    surface_id           TEXT,            -- for tool_error: the friction category (no surface join, surface_kind NULL); for file_edit: the basename hotspots group on (the full path is in target)
     source               TEXT,            -- kind-specific detail string: slash|tool (skill path); behavior class (prompt); a short error-text excerpt (tool_error); NULL otherwise
     started_at           TEXT NOT NULL,   -- RFC3339 UTC
     started_epoch        INTEGER NOT NULL,-- UTC unix seconds (bucketing)
@@ -56,7 +56,7 @@ CREATE TABLE events (
     sub_agent_count      INTEGER NOT NULL,
     sub_tokens_estimated INTEGER NOT NULL,
     model                TEXT,            -- representative model (skill_invocation); the originating tool name (tool_error)
-    target               TEXT,            -- the failed call's subject: file_path edited / command run (tool_error)
+    target               TEXT,            -- the failed call's subject: file_path edited / command run (tool_error); the edited file's full path (file_edit)
     attrs_json           TEXT
 );
 
@@ -165,6 +165,16 @@ Transcripts are append-only and **active sessions keep growing**, so re-running
 - `surfaces` is rebuilt wholesale on each run from current config — the catalog
   is a snapshot of *now*, not an accumulation. (Usage is historical; catalog is
   current — `surfaces.md`.)
+
+The fingerprint is keyed on the *file*, not on what cclens knew how to extract
+from it, so a store built by an older cclens keeps skipping transcripts that have
+since stopped changing — a closed session never re-ingests, and any field added
+after it was written stays NULL for that session. There is no schema version and
+no invalidation. The contract is that a reader **drops** such rows rather than
+substituting something plausible: `file_edit` rows with no `target` are excluded
+from thrash detection (`events.md`) instead of falling back to the basename,
+because a fallback would silently reproduce the merge the path exists to prevent.
+An emptied report is the signal to delete the store and re-analyze.
 
 `(mtime, size)` is a cheap change detector, not a content hash; a touch that
 changes mtime without changing bytes triggers a harmless idempotent replace, and

--- a/src/adapter/transcript.rs
+++ b/src/adapter/transcript.rs
@@ -349,11 +349,24 @@ fn error_excerpt(content: &Value) -> String {
     clean_truncate(&raw)
 }
 
-/// Extract work events `(epoch_ms, kind, id)` from a transcript: the leading
-/// word of each Bash command (`kind = "bash_cmd"`) and the basename of each
-/// Edit/Write target (`kind = "file_edit"`). These drive the command-mix and
-/// file-hotspot views — where effort (and churn) concentrates.
-pub fn extract_work_events(jsonl: &str) -> Vec<(i64, &'static str, String)> {
+/// One unit of work Claude performed: a Bash command or a file edit.
+pub struct WorkEvent {
+    pub epoch_ms: i64,
+    pub kind: &'static str,
+    /// The ranking identity: the command's leading word, or the edited file's
+    /// basename. Deliberately lossy — it is what groups a hotspot list.
+    pub id: String,
+    /// The edited file's full path (`file_edit` only). The basename cannot tell
+    /// two same-named files apart, which matters for thrash detection
+    /// (`core::thrash`) even though it does not for a hotspot ranking.
+    pub path: Option<String>,
+}
+
+/// Extract work events from a transcript: the leading word of each Bash command
+/// (`kind = "bash_cmd"`) and each Edit/Write target (`kind = "file_edit"`). These
+/// drive the command-mix and file-hotspot views — where effort (and churn)
+/// concentrates.
+pub fn extract_work_events(jsonl: &str) -> Vec<WorkEvent> {
     let mut events = Vec::new();
     for line in jsonl.lines() {
         let Ok(raw) = serde_json::from_str::<Raw>(line) else {
@@ -386,7 +399,12 @@ pub fn extract_work_events(jsonl: &str) -> Vec<(i64, &'static str, String)> {
                         .and_then(|v| v.as_str())
                         .and_then(|c| c.split_whitespace().next())
                     {
-                        events.push((ts, "bash_cmd", cmd.to_string()));
+                        events.push(WorkEvent {
+                            epoch_ms: ts,
+                            kind: "bash_cmd",
+                            id: cmd.to_string(),
+                            path: None,
+                        });
                     }
                 }
                 "Edit" | "Write" | "NotebookEdit" => {
@@ -394,8 +412,12 @@ pub fn extract_work_events(jsonl: &str) -> Vec<(i64, &'static str, String)> {
                         .and_then(|i| i.get("file_path"))
                         .and_then(|v| v.as_str())
                     {
-                        let base = path.rsplit('/').next().unwrap_or(path).to_string();
-                        events.push((ts, "file_edit", base));
+                        events.push(WorkEvent {
+                            epoch_ms: ts,
+                            kind: "file_edit",
+                            id: path.rsplit('/').next().unwrap_or(path).to_string(),
+                            path: Some(path.to_string()),
+                        });
                     }
                 }
                 _ => {}
@@ -573,10 +595,14 @@ mod tests {
             r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/a/b/cli.rs"}}]}}"#,
         );
         let events = extract_work_events(jsonl);
-        assert_eq!(events[0].1, "bash_cmd");
-        assert_eq!(events[0].2, "cd"); // leading word only
-        assert_eq!(events[1].1, "file_edit");
-        assert_eq!(events[1].2, "cli.rs"); // basename
+        assert_eq!(events[0].kind, "bash_cmd");
+        assert_eq!(events[0].id, "cd"); // leading word only
+        assert_eq!(events[0].path, None);
+        assert_eq!(events[1].kind, "file_edit");
+        assert_eq!(events[1].id, "cli.rs"); // basename, for hotspot ranking
+        // The full path rides along so thrash detection can tell two same-named
+        // files apart.
+        assert_eq!(events[1].path.as_deref(), Some("/a/b/cli.rs"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -470,31 +470,22 @@ fn collect_findings(store: &Store) -> Result<optimize_mod::Findings> {
         .take(15)
         .collect();
 
-    // Thrash per project — a burst belongs to the project it happened in.
-    let mut edits_by_project: std::collections::HashMap<String, Vec<(String, i64)>> =
-        std::collections::HashMap::new();
-    for (project, file, epoch) in store.work_event_rows_by_project("file_edit")? {
-        edits_by_project
-            .entry(project)
-            .or_default()
-            .push((file, epoch));
-    }
+    // Thrash per project — a burst belongs to the project it happened in. Each
+    // episode already knows its project, so detection runs once over everything.
     let mut thrash_by_project: std::collections::HashMap<String, Vec<optimize_mod::ThrashLine>> =
-        edits_by_project
-            .into_iter()
-            .map(|(project, edits)| {
-                let lines = detect_thrash(&edits, 5 * 60, 4)
-                    .into_iter()
-                    .take(5)
-                    .map(|w| optimize_mod::ThrashLine {
-                        span_secs: w.span_secs(),
-                        file: w.file,
-                        edits: w.edits,
-                    })
-                    .collect();
-                (project, lines)
-            })
-            .collect();
+        std::collections::HashMap::new();
+    for episode in detect_thrash(&store.file_edits()?, 5 * 60, 4) {
+        let lines = thrash_by_project
+            .entry(episode.project.clone())
+            .or_default();
+        if lines.len() < 5 {
+            lines.push(optimize_mod::ThrashLine {
+                span_secs: episode.span_secs(),
+                file: episode.file().to_string(),
+                edits: episode.edits,
+            });
+        }
+    }
 
     // Config wedges, split by the surface's own scope.
     let scoped = config_wedges(store)?;
@@ -1030,18 +1021,22 @@ fn tilde_path(path: &str) -> String {
 
 /// Thrash bursts: a file edited many times in a short window — where Claude got
 /// stuck and kept retrying, as opposed to a hotspot's healthy spread-out edits.
+/// An episode is one session's edits to one path, so parallel work on a
+/// same-named file is never presented as one agent looping (`core::thrash`).
 fn stuck(format: Format, frozen: bool, db: &Path) -> Result<()> {
     const GAP_SECS: i64 = 5 * 60;
     const MIN_EDITS: u32 = 4;
     let store = open_for_read(db, frozen)?;
-    let edits = store.work_event_rows("file_edit")?;
-    let episodes = detect_thrash(&edits, GAP_SECS, MIN_EDITS);
+    let episodes = detect_thrash(&store.file_edits()?, GAP_SECS, MIN_EDITS);
     if format == Format::Json {
         let episodes: Vec<serde_json::Value> = episodes
             .iter()
             .map(|e| {
                 serde_json::json!({
-                    "file": e.file,
+                    "project": e.project,
+                    "session_id": e.session_id,
+                    "file": e.file(),
+                    "path": e.path,
                     "edits": e.edits,
                     "span_secs": e.span_secs(),
                 })
@@ -1064,20 +1059,23 @@ fn stuck(format: Format, frozen: bool, db: &Path) -> Result<()> {
         .map(|e| {
             let span = e.span_secs();
             vec![
-                e.file.clone(),
+                e.project.clone(),
+                e.file().to_string(),
                 e.edits.to_string(),
                 format!("{}m{}s", span / 60, span % 60),
             ]
         })
         .collect();
     render(
-        &["file", "edits", "within"],
-        &[Align::Left, Align::Right, Align::Right],
+        &["project", "file", "edits", "within"],
+        &[Align::Left, Align::Left, Align::Right, Align::Right],
         &rows,
         format,
     );
     note(&format!(
-        "bursts of >= {MIN_EDITS} edits to one file within {}m — likely where Claude got stuck.",
+        "bursts of >= {MIN_EDITS} edits to one file within {}m by a single session —\n\
+         likely where Claude got stuck. `--format json` carries the session id and\n\
+         full path to investigate with.",
         GAP_SECS / 60
     ));
     Ok(())
@@ -1492,8 +1490,13 @@ fn run_analyze(projects: Option<PathBuf>, db: &Path) -> Result<AnalyzeStats> {
             })
             .collect();
         store.ingest_tool_errors(&meta.id, &meta.source_path, &error_rows)?;
+        // `work` owns the strings; the rows borrow them.
         let work = extract_work_events(&text);
-        store.ingest_work_events(&meta.id, &meta.source_path, &work)?;
+        let work_rows: Vec<(i64, &str, &str, Option<&str>)> = work
+            .iter()
+            .map(|e| (e.epoch_ms, e.kind, e.id.as_str(), e.path.as_deref()))
+            .collect();
+        store.ingest_work_events(&meta.id, &meta.source_path, &work_rows)?;
         if let Some((mtime, _)) = fingerprint {
             // Record the size actually consumed, so a tail appended after the
             // read shows a mismatch next run instead of being skipped forever.

--- a/src/core/thrash.rs
+++ b/src/core/thrash.rs
@@ -6,10 +6,24 @@
 
 use std::collections::HashMap;
 
-/// A burst of rapid re-edits to one file.
+/// One edit to one file, with the work context that makes it comparable to
+/// another edit: the same path touched by a different session is different work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileEdit {
+    pub session_id: String,
+    pub project: String,
+    /// The edited file's full path — not its basename. Two `route.ts` files in
+    /// different directories are different files.
+    pub path: String,
+    pub epoch: i64,
+}
+
+/// A burst of rapid re-edits to one file by one session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThrashEpisode {
-    pub file: String,
+    pub project: String,
+    pub session_id: String,
+    pub path: String,
     pub edits: u32,
     pub start_epoch: i64,
     pub end_epoch: i64,
@@ -19,19 +33,53 @@ impl ThrashEpisode {
     pub fn span_secs(&self) -> i64 {
         self.end_epoch - self.start_epoch
     }
+
+    /// The edited file's basename — what a report shows; the full `path`
+    /// disambiguates when two projects share a name.
+    pub fn file(&self) -> &str {
+        self.path.rsplit('/').next().unwrap_or(&self.path)
+    }
 }
 
-/// Find thrash episodes: per file, maximal runs of edits where each edit is
-/// within `gap_secs` of the previous, keeping only runs of at least `min_edits`.
-/// Sorted by edit count, densest first.
-pub fn detect_thrash(edits: &[(String, i64)], gap_secs: i64, min_edits: u32) -> Vec<ThrashEpisode> {
-    let mut by_file: HashMap<&str, Vec<i64>> = HashMap::new();
-    for (file, epoch) in edits {
-        by_file.entry(file).or_default().push(*epoch);
+/// Find thrash episodes: per `(session, path)`, maximal runs of edits where each
+/// edit is within `gap_secs` of the previous, keeping only runs of at least
+/// `min_edits`. Sorted by edit count, densest first.
+///
+/// The grouping key is what makes an episode mean "one agent kept retrying this
+/// file". Keying on the basename alone merged unrelated work — parallel sessions
+/// and worktrees editing a same-named file were reported as one agent stuck in a
+/// loop, which is exactly the signal this is supposed to detect. `session_id`
+/// implies the project, and the path is unique within it, so the pair is
+/// sufficient.
+///
+/// The trade is deliberate: thrash that genuinely continues across a resume or
+/// `/clear` now splits into one episode per session. A split under-reports a
+/// real burst; a merge invents one that never happened.
+pub fn detect_thrash(edits: &[FileEdit], gap_secs: i64, min_edits: u32) -> Vec<ThrashEpisode> {
+    let mut by_file: HashMap<(&str, &str), Vec<i64>> = HashMap::new();
+    for edit in edits {
+        by_file
+            .entry((edit.session_id.as_str(), edit.path.as_str()))
+            .or_default()
+            .push(edit.epoch);
     }
+    // The project travels with the session, so one lookup per session suffices.
+    let project_of: HashMap<&str, &str> = edits
+        .iter()
+        .map(|edit| (edit.session_id.as_str(), edit.project.as_str()))
+        .collect();
 
     let mut episodes = Vec::new();
-    for (file, mut times) in by_file {
+    for ((session_id, path), mut times) in by_file {
+        let project = project_of.get(session_id).copied().unwrap_or_default();
+        let at = |edits, start, end| Group {
+            project,
+            session_id,
+            path,
+            edits,
+            start,
+            end,
+        };
         times.sort_unstable();
         let mut start = times[0];
         let mut prev = times[0];
@@ -40,30 +88,45 @@ pub fn detect_thrash(edits: &[(String, i64)], gap_secs: i64, min_edits: u32) -> 
             if t - prev <= gap_secs {
                 count += 1;
             } else {
-                push_if(&mut episodes, file, count, start, prev, min_edits);
+                push_if(&mut episodes, at(count, start, prev), min_edits);
                 start = t;
                 count = 1;
             }
             prev = t;
         }
-        push_if(&mut episodes, file, count, start, prev, min_edits);
+        push_if(&mut episodes, at(count, start, prev), min_edits);
     }
 
     episodes.sort_by(|a, b| {
         b.edits
             .cmp(&a.edits)
             .then(b.span_secs().cmp(&a.span_secs()))
+            // Ties would otherwise order by HashMap iteration — unstable output.
+            .then(a.path.cmp(&b.path))
+            .then(a.session_id.cmp(&b.session_id))
     });
     episodes
 }
 
-fn push_if(out: &mut Vec<ThrashEpisode>, file: &str, edits: u32, start: i64, end: i64, min: u32) {
-    if edits >= min {
+/// One candidate run, before the `min_edits` cut.
+struct Group<'a> {
+    project: &'a str,
+    session_id: &'a str,
+    path: &'a str,
+    edits: u32,
+    start: i64,
+    end: i64,
+}
+
+fn push_if(out: &mut Vec<ThrashEpisode>, group: Group<'_>, min: u32) {
+    if group.edits >= min {
         out.push(ThrashEpisode {
-            file: file.to_string(),
-            edits,
-            start_epoch: start,
-            end_epoch: end,
+            project: group.project.to_string(),
+            session_id: group.session_id.to_string(),
+            path: group.path.to_string(),
+            edits: group.edits,
+            start_epoch: group.start,
+            end_epoch: group.end,
         });
     }
 }
@@ -72,44 +135,100 @@ fn push_if(out: &mut Vec<ThrashEpisode>, file: &str, edits: u32, start: i64, end
 mod tests {
     use super::*;
 
-    fn edit(file: &str, epoch: i64) -> (String, i64) {
-        (file.to_string(), epoch)
+    fn edit(path: &str, epoch: i64) -> FileEdit {
+        edit_in("s1", "demo", path, epoch)
+    }
+
+    fn edit_in(session_id: &str, project: &str, path: &str, epoch: i64) -> FileEdit {
+        FileEdit {
+            session_id: session_id.to_string(),
+            project: project.to_string(),
+            path: path.to_string(),
+            epoch,
+        }
     }
 
     #[test]
     fn rapid_reedits_to_one_file_are_a_thrash_episode() {
         // Three edits within 60s of each other.
-        let edits = [edit("a.rs", 0), edit("a.rs", 30), edit("a.rs", 50)];
+        let edits = [edit("/p/a.rs", 0), edit("/p/a.rs", 30), edit("/p/a.rs", 50)];
         let episodes = detect_thrash(&edits, 60, 3);
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].edits, 3);
         assert_eq!(episodes[0].span_secs(), 50);
+        assert_eq!(episodes[0].file(), "a.rs");
     }
 
     #[test]
     fn edits_spread_out_are_not_thrash() {
         // Same count, but each edit is far from the last — healthy development.
-        let edits = [edit("a.rs", 0), edit("a.rs", 1000), edit("a.rs", 2000)];
+        let edits = [
+            edit("/p/a.rs", 0),
+            edit("/p/a.rs", 1000),
+            edit("/p/a.rs", 2000),
+        ];
         assert!(detect_thrash(&edits, 60, 3).is_empty());
     }
 
     #[test]
     fn a_run_below_the_minimum_is_ignored() {
-        let edits = [edit("a.rs", 0), edit("a.rs", 10)];
+        let edits = [edit("/p/a.rs", 0), edit("/p/a.rs", 10)];
         assert!(detect_thrash(&edits, 60, 3).is_empty());
     }
 
     #[test]
     fn separate_bursts_of_the_same_file_are_separate_episodes() {
         let edits = [
-            edit("a.rs", 0),
-            edit("a.rs", 10),
-            edit("a.rs", 20), // burst 1
-            edit("a.rs", 5000),
-            edit("a.rs", 5010),
-            edit("a.rs", 5020), // burst 2 after a long gap
+            edit("/p/a.rs", 0),
+            edit("/p/a.rs", 10),
+            edit("/p/a.rs", 20), // burst 1
+            edit("/p/a.rs", 5000),
+            edit("/p/a.rs", 5010),
+            edit("/p/a.rs", 5020), // burst 2 after a long gap
         ];
         let episodes = detect_thrash(&edits, 60, 3);
         assert_eq!(episodes.len(), 2);
+    }
+
+    #[test]
+    fn concurrent_sessions_editing_the_same_file_are_not_one_episode() {
+        // Two agents working the same file in parallel. Interleaved in time, so
+        // merging them fabricates a single agent retrying six times.
+        let edits = [
+            edit_in("s1", "demo", "/p/a.rs", 0),
+            edit_in("s2", "demo", "/p/a.rs", 5),
+            edit_in("s1", "demo", "/p/a.rs", 10),
+            edit_in("s2", "demo", "/p/a.rs", 15),
+            edit_in("s1", "demo", "/p/a.rs", 20),
+            edit_in("s2", "demo", "/p/a.rs", 25),
+        ];
+        let episodes = detect_thrash(&edits, 60, 3);
+        assert_eq!(episodes.len(), 2);
+        assert!(episodes.iter().all(|e| e.edits == 3));
+    }
+
+    #[test]
+    fn same_basename_in_different_directories_is_not_one_episode() {
+        // One session touching two different route.ts files is not thrash.
+        let edits = [
+            edit("/p/users/route.ts", 0),
+            edit("/p/posts/route.ts", 5),
+            edit("/p/users/route.ts", 10),
+            edit("/p/posts/route.ts", 15),
+        ];
+        assert!(detect_thrash(&edits, 60, 3).is_empty());
+    }
+
+    #[test]
+    fn an_episode_carries_the_project_and_session_that_produced_it() {
+        let edits = [
+            edit_in("s9", "acme", "/p/a.rs", 0),
+            edit_in("s9", "acme", "/p/a.rs", 10),
+            edit_in("s9", "acme", "/p/a.rs", 20),
+        ];
+        let episodes = detect_thrash(&edits, 60, 3);
+        assert_eq!(episodes[0].project, "acme");
+        assert_eq!(episodes[0].session_id, "s9");
+        assert_eq!(episodes[0].path, "/p/a.rs");
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,6 +10,7 @@ use rusqlite::Connection;
 
 use crate::core::span::{Source, Span};
 use crate::core::surface::Surface;
+use crate::core::thrash::FileEdit;
 use crate::core::usage::UsageEvent;
 
 const SCHEMA: &str = "
@@ -388,50 +389,57 @@ impl Store {
 
     /// Insert work events `(epoch_ms, kind, id)` — Bash leading words and edited
     /// file basenames — kept out of the catalog join (`surface_kind` NULL).
+    /// Persist work events as `(epoch_ms, kind, id, path)`. A file edit's full
+    /// path goes to `target` — the generic detail column
+    /// (`docs/specs/storage.md`) — while `surface_id` keeps the basename that
+    /// hotspot rankings group on.
     pub fn ingest_work_events(
         &mut self,
         session_id: &str,
         source_path: &str,
-        events: &[(i64, &str, String)],
+        events: &[(i64, &str, &str, Option<&str>)],
     ) -> Result<()> {
         let tx = self.conn.transaction()?;
-        for (epoch_ms, kind, id) in events {
+        for (epoch_ms, kind, id, path) in events {
             tx.execute(
                 "INSERT INTO events
-                   (session_id, source_path, kind, surface_id,
+                   (session_id, source_path, kind, surface_id, target,
                     started_at, started_epoch, duration_sec, out_tokens, ctx_growth,
                     ctx_start, ctx_peak)
-                 VALUES (?1, ?2, ?3, ?4, '', ?5, 0, 0, 0, 0, 0)",
-                (session_id, source_path, *kind, id, epoch_ms / 1000),
+                 VALUES (?1, ?2, ?3, ?4, ?5, '', ?6, 0, 0, 0, 0, 0)",
+                (session_id, source_path, kind, id, path, epoch_ms / 1000),
             )?;
         }
         tx.commit()?;
         Ok(())
     }
 
-    /// Raw work events of a kind as `(project, id, started_epoch)`, time-ordered
-    /// — burst/thrash detection per project, so a burst is reported under the
-    /// project it happened in.
-    pub fn work_event_rows_by_project(&self, kind: &str) -> Result<Vec<(String, String, i64)>> {
+    /// Every file edit as a `FileEdit`, time-ordered — the input to thrash
+    /// detection, which needs the session and full path to tell one agent's
+    /// retries apart from parallel work on a same-named file (`core::thrash`).
+    ///
+    /// Rows without a recorded path are **excluded**, not fallen back to the
+    /// basename in `surface_id`: grouping same-named files together is the bug
+    /// this query exists to avoid, and a silent fallback would reproduce it for
+    /// every store written before paths were recorded — invisibly, since the
+    /// output would look normal. An empty result surfaces as "no thrash
+    /// episodes", which tells the user to re-analyze.
+    pub fn file_edits(&self) -> Result<Vec<FileEdit>> {
         let mut stmt = self.conn.prepare(
-            "SELECT s.project, e.surface_id, e.started_epoch
+            "SELECT s.project, e.session_id, e.target, e.started_epoch
              FROM events e JOIN sessions s ON e.session_id = s.id
-             WHERE e.kind = ?1 ORDER BY e.started_epoch",
+             WHERE e.kind = 'file_edit' AND e.target IS NOT NULL
+             ORDER BY e.started_epoch",
         )?;
         let rows = stmt
-            .query_map([kind], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        Ok(rows)
-    }
-
-    /// Raw work events of a kind as `(id, started_epoch)`, time-ordered — for
-    /// burst/thrash detection where individual timestamps matter.
-    pub fn work_event_rows(&self, kind: &str) -> Result<Vec<(String, i64)>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT surface_id, started_epoch FROM events WHERE kind = ?1 ORDER BY started_epoch",
-        )?;
-        let rows = stmt
-            .query_map([kind], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .query_map([], |row| {
+                Ok(FileEdit {
+                    project: row.get(0)?,
+                    session_id: row.get(1)?,
+                    path: row.get(2)?,
+                    epoch: row.get(3)?,
+                })
+            })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(rows)
     }
@@ -1271,7 +1279,7 @@ mod tests {
     }
 
     #[test]
-    fn work_event_rows_carry_their_project() {
+    fn file_edits_carry_their_project_session_and_full_path() {
         let mut store = Store::in_memory().unwrap();
         let mut alpha = session("a1");
         alpha.project = "alpha".to_string();
@@ -1280,14 +1288,38 @@ mod tests {
             .ingest_work_events(
                 "a1",
                 &alpha.source_path,
-                &[(1_000, "file_edit", "x.rs".to_string())],
+                &[(1_000, "file_edit", "x.rs", Some("/repo/src/x.rs"))],
             )
             .unwrap();
 
         assert_eq!(
-            store.work_event_rows_by_project("file_edit").unwrap(),
-            vec![("alpha".to_string(), "x.rs".to_string(), 1)]
+            store.file_edits().unwrap(),
+            vec![FileEdit {
+                project: "alpha".to_string(),
+                session_id: "a1".to_string(),
+                path: "/repo/src/x.rs".to_string(),
+                epoch: 1,
+            }]
         );
+    }
+
+    #[test]
+    fn a_file_edit_without_a_recorded_path_is_excluded() {
+        // Falling back to the basename would silently regroup same-named files —
+        // the very merge this query exists to prevent — for every store written
+        // before paths were recorded.
+        let mut store = Store::in_memory().unwrap();
+        let alpha = session("a1");
+        store.ingest_session(&alpha, &[], &[]).unwrap();
+        store
+            .ingest_work_events(
+                "a1",
+                &alpha.source_path,
+                &[(1_000, "file_edit", "x.rs", None)],
+            )
+            .unwrap();
+
+        assert_eq!(store.file_edits().unwrap(), vec![]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2

## Problem

A thrash episode claims *"one agent kept retrying this file"*, but `detect_thrash` grouped edits by **basename alone** — the only identity `extract_work_events` kept (`path.rsplit('/').next()`). Edits to a same-named file from parallel sessions, worktrees, and unrelated projects merged into one timeline, so ordinary parallel work was presented as an agent stuck in a loop.

Reproduced against a real store (48 sessions / 11 projects):

- **20 of 179 episodes spanned more than one session**; one spanned more than one project
- common filenames were the worst affected — one appeared across six projects, another across three
- several episodes of 12–14 edits were each split across two different sessions

The loudest rows were the least trustworthy — the opposite of what the report is for.

`optimize` already ran detection per project via `work_event_rows_by_project()`; only `stuck` used the unscoped `work_event_rows()`. So this was an inconsistency inside the codebase, not just an oversight.

## Fix

Group on `(session_id, path)`. The session implies the project and the path is unique within it, so the pair is sufficient — no need to add `project` to the key. Same store: **179 → 163 episodes**.

Note this is a **stronger key than the issue proposed**. `(project, session_id, basename)` would not have been enough:

- worktrees get distinct project slugs, so `project` in the key both over- and under-splits
- one session editing two same-named files in different directories still merges under a basename key

The real fix is storing the path, which the issue's suggested SQL does not do.

## Storing the path

`file_edit` now records the full path in `target` (the existing generic detail column — no schema change; only `tool_error` used it, and only via a kind-scoped view). `surface_id` keeps the basename, so hotspot rankings are unchanged.

**Rows without a recorded path are excluded from detection, not fallen back to the basename.** Incremental ingest never re-reads a closed session, so a `COALESCE(target, surface_id)` fallback would silently restore the merge for every store written before this — and the output would look completely normal. An emptied report surfaces as "no thrash episodes — run analyze first", which is the honest signal to delete the store and re-analyze.

## Deliberate trade-off (visible output change)

Thrash that genuinely continues across a resume or `/clear` now **splits into one episode per session**. Episode counts get smaller. This is intentional: a split under-reports a real burst; a merge invents one that never happened.

## Output

Episodes carry their project and session, so `optimize` no longer pre-groups edits by project. The human table gains a `project` column; `--format json` adds `session_id` and `path` — the issue's point that an episode nobody can locate cannot be investigated.

## API change

`work_event_rows` and `work_event_rows_by_project` are removed in favour of `file_edits() -> Vec<FileEdit>`. `extract_work_events` now returns `Vec<WorkEvent>` instead of tuples.

## Verification

- 3 new core tests, including the regression the issue asks for (two concurrent sessions editing the same basename → two episodes, not one) and same-basename-different-directory
- 2 store tests covering path round-trip and the no-path exclusion
- Episode sort now breaks ties on path/session so output no longer depends on `HashMap` iteration order
- `just check` and `just test` green (127 passed)
- Specs updated per `.claude/rules/spec-sync.md`: `events.md` (`file_edit`/`bash_cmd` kinds + why both basename and path are stored), `storage.md` (column semantics + the incremental-ingest gap), `cli.md` (`stuck` output and thrash routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)