### PR TITLE
fix(config): count a symlinked AGENTS.md as one always-on surface

### DIFF
--- a/docs/specs/config-format.md
+++ b/docs/specs/config-format.md
@@ -31,6 +31,16 @@ was deleted since its sessions ran simply contributes no project surfaces.
 | `mcp_server` | `~/.claude/mcp.json` (top-level `mcpServers`) | `<project>/.mcp.json` |
 | `mcp_tool` | the MCP server's advertised tool schemas (dynamic — see below) | — |
 
+`CLAUDE.md` and `AGENTS.md` are two names for the same always-on context, and a
+repo serving both agent conventions typically ships `AGENTS.md` as a symlink to
+`CLAUDE.md`. Claude Code injects that content once, so the adapter weighs the
+file once: `read_project_surfaces` resolves each candidate and keeps the first
+surface per resolved file, which reports the pair under `CLAUDE.md`. The
+deduplication key is the resolved path, not the content — two independently
+maintained files are two real always-on surfaces even when their text coincides.
+Getting this wrong doubles the project's `startup_full` total, which is what the
+always-on floor is reconciled against (`surfaces.md`).
+
 `settings.json` carries two surface kinds at once: `permissions` (allow/deny) and
 `hooks` (matcher → command); the adapter splits one file into several surfaces.
 MCP servers are **not** in `settings.json` — they live in a separate `mcp.json`

--- a/src/adapter/config.rs
+++ b/src/adapter/config.rs
@@ -2,6 +2,7 @@
 //! adapter, the parsing core is pure (over file content) and the directory
 //! walking is a thin shell. See `docs/specs/config-format.md`.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -171,8 +172,20 @@ pub fn read_project_surfaces(root: &Path, project: &str) -> Vec<Surface> {
     surfaces.extend(read_rule_surfaces(&claude.join("rules"), &scope));
     surfaces.extend(read_agent_surfaces(&claude.join("agents"), &scope));
     surfaces.extend(read_mcp_server_surfaces(&root.join(".mcp.json"), &scope));
+    // A repo that serves both agent conventions usually ships `AGENTS.md` as a
+    // symlink to `CLAUDE.md`. Claude Code injects that content once, so weigh
+    // the file once too: resolve each candidate and keep the first surface per
+    // resolved file, which makes `CLAUDE.md` the one that is reported. Counting
+    // both would double the project's always-on figure and suggest deleting a
+    // link that costs nothing.
+    let mut seen = HashSet::new();
     for name in ["CLAUDE.md", "AGENTS.md"] {
-        if let Some(surface) = read_claude_md_surface(&root.join(name), name, &scope) {
+        let path = root.join(name);
+        let resolved = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if !seen.insert(resolved) {
+            continue;
+        }
+        if let Some(surface) = read_claude_md_surface(&path, name, &scope) {
             surfaces.push(surface);
         }
     }
@@ -335,6 +348,62 @@ mod tests {
         assert!(has("rule", "tdd"));
         assert!(has("claude_md", "CLAUDE.md"));
         assert!(has("mcp_server", "playwright"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_agents_md_symlinked_to_claude_md_is_one_surface() {
+        // A repo serving both agent conventions ships AGENTS.md as a symlink to
+        // CLAUDE.md. Claude Code injects that content once, so counting both
+        // paths would double the always-on figure and suggest deleting a link
+        // that costs nothing.
+        let root = std::env::temp_dir().join(format!(
+            "cclens-test-symlink-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        // Start from an empty directory: a leftover AGENTS.md from an aborted
+        // run would make the symlink below fail with AlreadyExists.
+        fs::remove_dir_all(&root).ok();
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("CLAUDE.md"), "project claude md").unwrap();
+        std::os::unix::fs::symlink("CLAUDE.md", root.join("AGENTS.md")).unwrap();
+
+        let surfaces = read_project_surfaces(&root, "alpha");
+        fs::remove_dir_all(&root).ok();
+
+        let claude_mds: Vec<_> = surfaces.iter().filter(|s| s.kind == "claude_md").collect();
+        assert_eq!(claude_mds.len(), 1);
+        assert_eq!(claude_mds[0].id, "CLAUDE.md");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_agents_md_of_its_own_stays_a_separate_surface() {
+        // Only the *same file* is deduplicated: a standalone AGENTS.md is real
+        // extra always-on context.
+        let root = std::env::temp_dir().join(format!(
+            "cclens-test-distinct-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        // Start from an empty directory: a leftover symlinked AGENTS.md from an
+        // aborted run would write through to CLAUDE.md and hide the two files.
+        fs::remove_dir_all(&root).ok();
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("CLAUDE.md"), "project claude md").unwrap();
+        fs::write(root.join("AGENTS.md"), "project agents md").unwrap();
+
+        let surfaces = read_project_surfaces(&root, "alpha");
+        fs::remove_dir_all(&root).ok();
+
+        let mut ids: Vec<_> = surfaces
+            .iter()
+            .filter(|s| s.kind == "claude_md")
+            .map(|s| s.id.as_str())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, ["AGENTS.md", "CLAUDE.md"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Deduplicate the project `CLAUDE.md` / `AGENTS.md` candidates in `read_project_surfaces` by their **resolved** path, keeping the first (so the pair is reported under `CLAUDE.md`).
- Add tests for both shapes: `AGENTS.md` symlinked to `CLAUDE.md` collapses to one surface; two independently written files stay two surfaces.
- Document the rule and its key in `docs/specs/config-format.md`.

## Why

A repo that serves both agent conventions usually ships `AGENTS.md` as a symlink to `CLAUDE.md`. `read_claude_md_surface` uses `fs::read_to_string`, which follows the link, so the same file was catalogued twice at full weight — two `ALWAYS-ON HEAVY` rows for one file, and a suggestion that deleting a 9-byte symlink would save ~1k tokens per session that it never cost.

It was not only cosmetic. `Store::always_on_config_tokens_for` sums `static_tokens` over every `startup_full` surface in scope, so the duplicate also inflated `overhead`'s `config_tokens` and understated the `floor - config_tokens` residual. Fixing it at the catalog source repairs both surfaces of the bug at once. (The global scope reads only `~/.claude/CLAUDE.md`, so it was never affected.)

The deduplication key is the resolved path, not the content: two independently maintained files are two real always-on surfaces even when their text happens to coincide, and collapsing those would understate the cost instead.

Closes #6

## Test Plan

- [x] `nix develop -c just test` — 137 passed / 0 failed
- [x] `nix develop -c just check` — rustfmt + clippy (`-D warnings`) clean
- [x] New unit test fails before the fix (2 surfaces) and passes after (1 surface, id `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6yDPVuQHhzU21u7qN5ExM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate reporting when `CLAUDE.md` and `AGENTS.md` refer to the same file.
  - Standalone `AGENTS.md` files continue to be recognized separately.
  - Corrected startup context totals to account for deduplicated configuration files.

- **Documentation**
  - Clarified how `CLAUDE.md` and `AGENTS.md` are handled, including symlinked configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->