### PR TITLE
Attribute subagent tokens to the agent types that spent them

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ derived store.
 - **Where the work stumbles** — recurring tool failures by category and
   originating tool (`failures`), files Claude got stuck re-editing (`stuck`),
   each with concrete examples and the project it concentrates in.
-- **Where tokens go** — main-thread skill output vs. subagent cost, and the
-  always-on context floor reconciled against your readable config (the residual
-  is system + tools + MCP you cannot trim from files).
+- **Where tokens go** — main-thread skill output vs. subagent cost, the subagent
+  half split per agent type (which agents actually spent it, nested spawns
+  included), and the always-on context floor reconciled against your readable
+  config (the residual is system + tools + MCP you cannot trim from files).
 - **How you prompt** — the steer / correct / question / instruct mix.
 
 ## Notes

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -70,9 +70,9 @@ ranking.
 
 | View | Answers |
 | --- | --- |
-| `doctor` | The entry point: a one-screen health check **written for someone who has never seen cclens's vocabulary** — every item says what happened, why it costs, and what to do. Sections: `WHAT TO FIX FIRST` (recurring problems as a prioritized to-do list, each routed to the owning config layer with the follow-up command), `COST` (the session-start context and output totals in plain words, humanized units), `CONFIG WORTH PRUNING` (dead or heavy config per owner), `LOOKS HEALTHY` (what explicitly needs no action). `--scope` narrows to one layer; the text form leads with actions, never a stats dump. |
+| `doctor` | The entry point: a one-screen health check **written for someone who has never seen cclens's vocabulary** — every item says what happened, why it costs, and what to do. Sections: `WHAT TO FIX FIRST` (recurring problems as a prioritized to-do list, each routed to the owning config layer with the follow-up command), `COST` (the session-start context and output totals in plain words, humanized units, naming the agent types behind the subagent figure), `CONFIG WORTH PRUNING` (dead or heavy config per owner), `LOOKS HEALTHY` (what explicitly needs no action). `--scope` narrows to one layer; the text form leads with actions, never a stats dump. |
 | `inventory` | The catalog×usage join per surface **row** (scope and owning project shown; usage attributed under per-project shadowing — `surfaces.md`): startup cost, static cost, load mode, usage. `--scope` filters to one layer; orphaned usage (no scope to filter on) appears in the unfiltered view only. |
-| `usage` | Skill event rollups: per skill, or per time bucket (`--by`) — frequency, tokens, `ctx_growth`, duration. Leads with a token-destination line (main-thread skill output vs subagent total) so the reader sees where tokens actually go before the table. |
+| `usage` | Skill event rollups: per skill, or per time bucket (`--by`) — frequency, tokens, `ctx_growth`, duration. Leads with a token-destination line (main-thread skill output vs subagent total) so the reader sees where tokens actually go before the table, then splits the subagent half **per agent type** (runs and output tokens, costliest first) — the aggregate is usually the larger number and the split is the part that can be acted on. A section with no rows is omitted rather than rendered as bare headers. |
 | `waste` | Just the flagged opportunities (unused, costly+rare, always-on heavy, …) with their evidence and owning scope; `--scope` filters to one layer. |
 | `overhead` | Reconcile the empirical always-on floor (the leanest observed **session start**, not the context a skill happened to run at — `surfaces.md`) against the readable always-on config; the residual is the system prompt + built-in tools + MCP schemas the catalog cannot weigh. The per-project table carries the session count behind each floor, because the floor is a minimum over observations and a project with few sessions may never have caught a fresh one. Reports the metric as unavailable when no session start was observed at all. |
 | `prompts` | How the user steers the session: the mix of steer / correct / question / instruct prompts (`core::prompt`, lexical heuristics), with a verdict — heavy steering suggests more autonomy, frequent correction suggests clearer upfront specs. This is a behavioral signal, not a config metric; embeddings showed prompt *topics* do not map to reusable skills, so the value is in *how* you prompt, not *what about*. |
@@ -140,6 +140,14 @@ caveats in `events.md` / `surfaces.md`):
   deletion never delivers.
 - "Unused" always carries the window it was evaluated over, so it is not mistaken
   for "never installed".
+- A subagent run whose agent type was never recorded is shown as `(unknown)`,
+  never merged into a named type and never dropped — the per-agent rows must
+  keep summing to the subagent total the same report prints above them.
+- When they *cannot* sum to it — a store predating the per-agent split, read
+  with `--frozen` so the refresh that would fill it never ran — the report says
+  so on stderr instead of letting an absent breakdown pass for a zero one
+  (`storage.md`'s report-the-gap contract). It rides with the freshness line
+  rather than in the table, so piped stdout and `--format json` stay clean.
 
 Meta-skills are not nested (`events.md`): a driver and the skills it ran are
 each their own span, so a child's cost lands on the child and no figure is

--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -18,7 +18,7 @@ identifying the configuration surface it exercises (the join key into
 | `kind` | Surface exercised | Span? |
 | --- | --- | --- |
 | `skill_invocation` | `skill` | yes — work window until the skill's activity ends |
-| `agent_spawn` | `agent` | the subagent's lifetime (cost attributed via `promptId`) |
+| `agent_spawn` | `agent` | no — point event; its cost is carried by the run it started (below) |
 | `tool_use` | `mcp_tool` / `mcp_server` / built-in tool | point event |
 | `prompt` | — (user input; raw material for skill extraction) | point event; text referenced, not stored |
 | `tool_error` | — (a failed `tool_result`) | point event; friction category in `surface_id`, a short error-text excerpt in `source`, the originating tool name in `model`, the call's target (file_path / command) in `target` |
@@ -178,30 +178,86 @@ the minimum across a project's sessions is what filters those out, which is why
 the session count travels with the floor in reports — one observation cannot be
 distinguished from one resumed session.
 
+## Subagent runs
+
+A **run** is one execution of one agent type, extracted from its own transcript
+plus the sidecar beside it (`session-format.md`). It is a first-class persisted
+row (`storage.md`), not an intermediate, because the session-level total answers
+only *how much* subagent work cost — never *whose*. Two agents with similar
+spawn counts can differ by an order of magnitude in output, and the spawn count
+alone cannot tell them apart; without runs, the largest figure in the report is
+the one nothing can be done about.
+
+A run carries the agent type, its own output tokens, its model, its depth in the
+spawn tree, and the ids that link it back: its own `tool_use_id`, its parent
+run, and the **root** `tool_use_id` its tree started at (`core::subagent`).
+
+- **Every run counts once, at its own cost, whatever its depth.** A nested run
+  is the agent that wrote those tokens; folding it into its parent's type would
+  bill an agent that only delegated. So the per-agent rows sum exactly to the
+  session-level total.
+- **A run whose agent type is unknown** (no sidecar) is kept, grouped under
+  "unknown". Dropping it would silently break that sum; guessing a type would
+  be worse.
+- **The root link is what crosses the boundary.** A nested run's own
+  `tool_use_id` names a call inside its *parent's* transcript, which no
+  main-thread span contains. Walking `parent_agent_id` to the tree's root gives
+  the one call the main thread actually made, so a subtree's cost lands on the
+  main-thread work that caused it. A broken chain (missing parent, or a cycle in
+  malformed input) leaves the run unrooted and unattributed rather than charged
+  to an arbitrary spawn.
+
 ## Subagent attribution
 
-A span's `sub_tokens` is the cost of subagents it spawned, joined by `promptId`
-(`session-format.md`). Because several subagents can share one `promptId` and a
-turn can contain more than one span that spawned subagents, the join is not
-always one-to-one.
+A span's `sub_tokens` is the cost of the runs it spawned. The join is tried at
+two precisions, and falls back only when it must:
 
-- A subagent is attributed to the span containing the `Agent` spawn for its
-  `promptId`. The spawning assistant record does not carry the `promptId`
-  itself, so the adapter threads the current turn's id forward and stamps it on
-  the spawn — that stamped id is what matches the subagent transcript.
-- When more than one span in the same `promptId` competes for the same
-  subagents, their tokens are **split equally** across the competing spans.
-- A subagent whose `promptId` matches no span (e.g. spawned outside any skill)
-  is not attributed per-span; it still counts in the session-level subagent
-  total, which is exact and needs no such join.
-- Any span whose `sub_tokens` includes an equally-split (not cleanly
-  attributable) subagent is marked `sub_tokens_estimated`. Equal-split is a
-  deliberate approximation — this tool ranks, it does not bill
-  (`architecture.md`) — and the flag lets reports separate exact figures from
-  estimates rather than hiding the uncertainty.
+1. **By spawn call.** A run rooted at a known `Agent` call is attributed to the
+   one span whose window contains that call. Spans do not overlap, so this
+   claims at most one span: the attribution is exact and is **never** flagged
+   estimated.
+2. **By turn.** Used **only when the run carries no call id at all** — an older
+   transcript with no sidecar. Then only `promptId` is left, and it identifies
+   the turn rather than the spawn: the run is claimed by every span that spawned
+   anything in that turn, and when more than one competes they **split its tokens
+   equally** and are each marked `sub_tokens_estimated`. A single claimant is not
+   flagged: the flag means *this figure was split*, which is what the metrics
+   table above defines it as.
 
-The worst-case error of equal-split is bounded by the spread of the competing
-subagents' sizes; the flag, not false precision, is the mitigation.
+The precisions are selected by what the run *knows*, never by whether the exact
+join happened to hit. Once a run carries a call id the turn join is never used
+for it, in either failing case:
+
+- **Its rooted call sits in no span.** The root already says which call spawned
+  it, so no span containing that call means it was spawned outside every span.
+- **Its parent chain is broken** (a missing parent, or a cycle in malformed
+  input), so it has no root. The call id still shows it was spawned by another
+  subagent rather than from the main thread.
+
+Retrying by turn in either case would charge the run to whichever unrelated span
+happened to spawn something in the same turn — the exact error the call id
+exists to prevent.
+
+A run matching no span (spawned outside any skill, or unrooted) is not
+attributed per-span; it still counts in the session-level total, which is exact
+and needs no join.
+
+Equal-split is a deliberate approximation — this tool ranks, it does not bill
+(`architecture.md`) — and its worst-case error is bounded by the spread of the
+competing runs' sizes. The flag, not false precision, is the mitigation, and it
+now marks only the runs that genuinely could not be resolved.
+
+### The spawn event carries the run's cost
+
+An `agent_spawn` event and a run describe one subagent from opposite sides: the
+event is what the main thread *did*, the run is what it *cost*. They are joined
+by the spawn call's id, so the event's `out_tokens` is the run's own output and
+its `sub_tokens` the output of everything that run spawned in turn. A spawn
+whose run is missing keeps zeros rather than borrowing another's figures.
+
+This is why the spawn stays a point event rather than growing a window: its cost
+is measured in the subagent's transcript, not inferred from main-thread records
+inside a guessed boundary.
 
 ### Per-span attribution is window-bounded, not authoritative
 
@@ -213,11 +269,17 @@ subagents spawned by *later, same-window* activity. Observed in real data: a
 that ran after the commit in the same turn. There is no transcript marker for
 "the skill returned", so this cannot be tightened structurally.
 
+Joining by the spawn call instead of the turn does not fix this: the call is
+inside the window either way, so the window is still the thing being trusted.
+What it fixes is the *other* half — a span that spawned nothing in that turn no
+longer takes a share.
+
 Therefore `events.sub_tokens` is recorded per span (queryable, and exact for
 skills that genuinely spawn their own agents) but is **not rolled up into the
 per-skill report**, where it would over-count. The authoritative subagent figure
 is the **session-level total** (`sessions.sub_tokens`), which is exact — every
-subagent transcript counted once, no window guess involved.
+subagent run counted once, no window guess involved — and the per-agent split of
+that total (`subagent_runs`) is exact for the same reason.
 
 ## Determinism
 

--- a/docs/specs/session-format.md
+++ b/docs/specs/session-format.md
@@ -19,6 +19,7 @@ two specs most likely to change when Claude Code ships a new release.
     <sessionId>.jsonl                          ← main session transcript
     <sessionId>/subagents/
       agent-<agentId>.jsonl                    ← one transcript per spawned subagent
+      agent-<agentId>.meta.json                ← that subagent's sidecar (below)
 ```
 
 - `<cwd-slug>` encodes the working directory (path separators → `-`). Worktree
@@ -150,15 +151,44 @@ duplicates of one event** — empirically a `slash` is not shadowed by a matchin
 ## Subagent linkage
 
 Subagent cost is attributed back to the event that spawned the work, but a
-subagent's tokens live in a separate file. The structural join is **`promptId`**:
+subagent's tokens live in a separate file, and its own transcript never names
+the **agent type** that ran. Both facts come from the sidecar; `promptId` is the
+fallback when there is none.
+
+Each `agent-<agentId>.jsonl` has a sibling `agent-<agentId>.meta.json`:
+
+| Field | Use |
+| --- | --- |
+| `agentType` | The agent that ran (`Explore`, a custom agent's name) — the only place it appears. Without it a run's cost cannot be attributed to a type at all. |
+| `toolUseId` | The `id` of the `Agent` `tool_use` block that spawned this run — an **exact** join to one spawn. |
+| `parentAgentId` | For a subagent spawned by a subagent, the parent's `agentId`. Absent at depth 1. |
+| `spawnDepth` | 1 for a main-thread spawn, 2+ for a nested one. |
+| `model` | The model the run used. |
+
+The transcript side of the same join:
 
 - A subagent transcript's records carry `agentId`, `sessionId`, and `promptId`;
   the file is `agent-<agentId>.jsonl`.
 - The same `promptId` appears on the parent session's records for the spawning
-  turn.
-- There is **no** direct `Agent` `tool_use.id` → `agentId` link, so `promptId`
-  is the only reliable join. Several subagents can share one `promptId` (parallel
-  spawn), making per-event attribution approximate — see `events.md`.
+  turn. It is inherited by the **whole** subagent tree, so a nested run's
+  `promptId` is still the top-level turn's — it identifies the turn, never the
+  spawn.
+- Several subagents share one `promptId` (parallel spawn, and every nested run),
+  so `promptId` alone makes per-event attribution approximate. `toolUseId` does
+  not: it names one call. The adapter therefore keeps the `Agent` block's `id`
+  on the spawn record and prefers that join, falling back to `promptId` only
+  when a sidecar is missing — see `events.md`.
+
+**Nested runs exist only here.** An agent spawned by an agent has no `Agent`
+`tool_use` anywhere in the main transcript, so the main thread's spawn count is
+not the number of subagent runs; the `subagents/` directory is. Observed on a
+real tree: roughly half of all runs were nested, and one agent type ran seven
+times more often than the main transcript alone suggested.
+
+> The sidecar was observed on transcript versions `2.1.220`–`2.1.246`, present
+> for every subagent transcript in the tree. Earlier releases may not write it,
+> so every field is read as optional and an absent sidecar degrades to the
+> `promptId` join with an unknown agent type — never to a guessed one.
 
 ## Subagents do not invoke skills
 

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -1,8 +1,9 @@
 # Storage Specification
 
 The store is the SQLite database `analyze` writes and every consumer reads
-(`architecture.md`). It holds three tables that mirror the catalog×usage model —
-a shared `sessions` dimension, the `surfaces` catalog, the `events` spine — plus
+(`architecture.md`). It holds the tables that mirror the catalog×usage model —
+a shared `sessions` dimension, the `surfaces` catalog, the `events` spine, and
+`subagent_runs` for work that happened in its own transcript — plus
 `ingested_files` for incremental rebuilds. This spec defines the schema and the
 ingest contract; the *meaning* of the columns lives in the specs that own them
 (`events.md`, `surfaces.md`, `config-format.md`).
@@ -12,13 +13,15 @@ ingest contract; the *meaning* of the columns lives in the specs that own them
 ```sql
 -- Shared dimension. One row per analyzed transcript.
 CREATE TABLE sessions (
-    id          TEXT PRIMARY KEY,   -- sessionId
-    project     TEXT NOT NULL,      -- normalized (worktree folded; see below)
-    slug        TEXT NOT NULL,      -- raw cwd-slug
-    root        TEXT NOT NULL,      -- real start directory (records' cwd, worktree folded); '' when unknown
-    source_path TEXT NOT NULL,      -- the main transcript file
-    started_at  TEXT NOT NULL,      -- RFC3339 UTC
-    version     TEXT                -- Claude Code version, when present
+    id              TEXT PRIMARY KEY,   -- sessionId
+    project         TEXT NOT NULL,      -- normalized (worktree folded; see below)
+    slug            TEXT NOT NULL,      -- raw cwd-slug
+    root            TEXT NOT NULL,      -- real start directory (records' cwd, worktree folded); '' when unknown
+    source_path     TEXT NOT NULL,      -- the main transcript file
+    started_at      TEXT NOT NULL,      -- RFC3339 UTC
+    sub_tokens      INTEGER NOT NULL,   -- the session's exact subagent output total (events.md)
+    sub_agent_count INTEGER NOT NULL,   -- subagent runs the session spawned, nested included
+    version         TEXT                -- Claude Code version, when present
 );
 
 -- Catalog: everything installed, with its static cost. Read from live config.
@@ -57,11 +60,35 @@ CREATE TABLE events (
     sub_agent_count      INTEGER NOT NULL,
     sub_tokens_estimated INTEGER NOT NULL,
     model                TEXT,            -- representative model (skill_invocation); the originating tool name (tool_error)
-    target               TEXT,            -- the failed call's subject: file_path edited / command run (tool_error); the edited file's full path (file_edit)
+    target               TEXT,            -- the failed call's subject: file_path edited / command run (tool_error); the edited file's full path (file_edit); the Agent call's id (agent_spawn), joining subagent_runs
     attrs_json           TEXT
 );
 
 CREATE INDEX events_by_surface ON events(surface_kind, surface_id);
+
+-- One row per subagent execution, from the subagent's own transcript and its
+-- sidecar (events.md). This is where "which agent types consumed those tokens?"
+-- is answered; the session total answers only "how many".
+CREATE TABLE subagent_runs (
+    id               INTEGER PRIMARY KEY,
+    session_id       TEXT NOT NULL REFERENCES sessions(id),
+    source_path      TEXT NOT NULL,   -- the parent session's transcript (ingest delete key)
+    run_path         TEXT NOT NULL,   -- the subagent's own transcript
+    agent            TEXT,            -- the agent type; NULL when no sidecar recorded it
+    agent_id         TEXT NOT NULL,
+    tool_use_id      TEXT,            -- the Agent call that spawned this run; joins events.target
+    root_tool_use_id TEXT,            -- the main-thread call its spawn tree started at
+    parent_agent_id  TEXT,            -- the run that spawned it, for a nested run
+    spawn_depth      INTEGER NOT NULL,-- 1 main-thread, 2+ nested
+    model            TEXT,
+    prompt_id        TEXT,            -- the spawning turn (the fallback join key)
+    out_tokens       INTEGER NOT NULL,
+    started_at       TEXT NOT NULL,   -- RFC3339 UTC
+    started_epoch    INTEGER NOT NULL
+);
+
+CREATE INDEX subagent_runs_by_agent  ON subagent_runs(agent);
+CREATE INDEX subagent_runs_by_source ON subagent_runs(source_path);
 
 -- Incremental-ingest fingerprints.
 CREATE TABLE ingested_files (
@@ -89,6 +116,12 @@ SELECT e.session_id, s.project,
 FROM events e JOIN sessions s ON e.session_id = s.id
 WHERE e.kind = 'tool_error';
 ```
+
+The `REFERENCES` annotations above record which column joins which table; they
+are **not declared constraints**. SQLite does not enforce foreign keys unless
+`PRAGMA foreign_keys` is on, and turning it on would constrain ingest ordering
+for what is a regenerable cache — so the schema states the relationship and the
+ingest code maintains it (delete-then-insert per `source_path`, below).
 
 The store is also a **read surface for arbitrary queries** (`cli.md`: `sql`).
 Because it is plain SQLite holding already-extracted facts, the session-analysis
@@ -238,6 +271,19 @@ Transcripts are append-only and **active sessions keep growing**, so re-running
   equals this file, then re-extract from the whole file and insert. This is why
   `events.source_path` exists. Replacing avoids duplicate rows when a still-open
   session is analyzed twice (the second pass simply supersedes the first).
+  `subagent_runs` replaces on the same key — the parent transcript's path, not
+  the subagent's — so one session's runs are rebuilt as a set, and a run whose
+  own transcript vanished does not survive as an orphan. The subagent files
+  themselves are deliberately **not** fingerprinted: a subagent's completion
+  appends its `tool_result` to the *main* transcript, so the parent's own
+  fingerprint already moves when a child finishes, and the next run re-reads the
+  whole directory. Stat-ing every file under `subagents/` on every run would buy
+  only the case of a session killed between the child finishing and that
+  `tool_result` being written — where the session's data is incomplete anyway. Filling an
+  `agent_spawn` row's cost from those runs is scoped to that same key: a call id
+  is unique **within** a session, and nothing guarantees it across sessions
+  (a resumed or copied transcript can carry one over), so an unscoped join would
+  pick an arbitrary row and sum another session's runs on top.
 - `surfaces` is rebuilt wholesale on each run from current config — the catalog
   is a snapshot of *now*, not an accumulation. (Usage is historical; catalog is
   current — `surfaces.md`.)
@@ -288,7 +334,7 @@ actually consumed. A file that grew during the read therefore shows a changed
 the fingerprint before the read would record the post-growth size against
 pre-growth events and permanently skip the tail.
 
-## Why these three tables, not one span table
+## Why a dimension + catalog + spine, not one span table
 
 An earlier design had a single skill-centric `spans` table. It could not hold
 rules, hooks, MCP, or prompts without contortion, and it conflated the catalog
@@ -296,3 +342,10 @@ rules, hooks, MCP, or prompts without contortion, and it conflated the catalog
 + `surfaces` (catalog) + `events` (usage) lets every configuration surface share
 one usage spine and one catalog shape, and makes the optimization analysis a
 join rather than a special case per surface — see `surfaces.md`.
+
+`subagent_runs` sits beside the spine rather than in it because a run is not an
+event *of the session* — it happened in another transcript, on another thread,
+and its cost was measured there. Putting it in `events` with `surface_kind =
+'agent'` would double-count every spawn in the catalog×usage join, which counts
+rows per surface. The spine keeps the main thread's spawn; the run keeps the
+cost; `events.target` joins them.

--- a/src/adapter/transcript.rs
+++ b/src/adapter/transcript.rs
@@ -5,6 +5,8 @@
 //! deserializes defensively: only the needed fields, unknown fields ignored, a
 //! line that fails to parse or lacks a timestamp simply yields no records.
 
+use std::path::{Path, PathBuf};
+
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -535,14 +537,69 @@ pub fn session_cwd(jsonl: &str) -> Option<String> {
     })
 }
 
-/// The `promptId` a subagent transcript was spawned under — the join key back to
-/// the spawning span. Read from the first record that carries one.
+/// The `promptId` a subagent transcript was spawned under — the coarse join key
+/// back to the spawning span. Read from the first record that carries one.
 pub fn subagent_prompt_id(jsonl: &str) -> Option<String> {
     jsonl.lines().find_map(|line| {
         serde_json::from_str::<Raw>(line)
             .ok()
             .and_then(|raw| raw.prompt_id)
     })
+}
+
+/// What a subagent transcript's **sidecar** says about the run: which agent type
+/// ran, which `Agent` call spawned it, and where it sits in the spawn tree.
+///
+/// The transcript itself never names the agent type, so without the sidecar a
+/// run's cost cannot be attributed to a type at all. Only the fields the tool
+/// needs are read, and every one is optional — a sidecar from a newer (or
+/// older) Claude Code still yields whatever it does carry, and a missing file
+/// yields `None` rather than a guess (`docs/specs/session-format.md`).
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(default)]
+pub struct SubagentSidecar {
+    #[serde(rename = "agentType")]
+    pub agent_type: Option<String>,
+    #[serde(rename = "toolUseId")]
+    pub tool_use_id: Option<String>,
+    #[serde(rename = "parentAgentId")]
+    pub parent_agent_id: Option<String>,
+    #[serde(rename = "spawnDepth")]
+    pub spawn_depth: Option<u32>,
+    pub model: Option<String>,
+}
+
+/// Parse a subagent sidecar's JSON. `None` when the text is not readable JSON —
+/// an absent or malformed sidecar leaves the run's type unknown, which every
+/// consumer reports as unknown rather than filling in.
+pub fn parse_subagent_sidecar(json: &str) -> Option<SubagentSidecar> {
+    serde_json::from_str(json).ok()
+}
+
+/// The subagent's own id, from its transcript file name `agent-<agentId>.jsonl`
+/// — the key a nested run's sidecar names as its parent.
+pub fn subagent_id_from_file_name(file_stem: &str) -> String {
+    file_stem
+        .strip_prefix("agent-")
+        .unwrap_or(file_stem)
+        .to_string()
+}
+
+/// Where a session's subagent transcripts live: `<sessionId>/subagents/` beside
+/// the main transcript (`docs/specs/session-format.md`).
+///
+/// A path rule, not a read — the shell still does the walking. It lives here
+/// because the *layout* is Claude Code's, so a release that moves these files
+/// changes this function and nothing downstream
+/// (`.claude/rules/format-isolation.md`).
+pub fn subagents_dir(transcript: &Path) -> PathBuf {
+    transcript.with_extension("").join("subagents")
+}
+
+/// The sidecar beside a subagent transcript: `agent-<id>.jsonl` →
+/// `agent-<id>.meta.json`.
+pub fn subagent_sidecar_path(run_path: &Path) -> PathBuf {
+    run_path.with_extension("meta.json")
 }
 
 fn parse_timestamp_ms(timestamp: &str) -> Option<i64> {
@@ -575,9 +632,11 @@ fn tool_use_kind(block: &Value) -> Option<RecordKind> {
                 .as_str()?
                 .to_string();
             // The spawning turn's prompt id is threaded in by parse_session; the
-            // Agent record itself does not carry it.
+            // Agent record itself does not carry it. The block's own id does
+            // identify this call, and the spawned transcript names it back.
             Some(RecordKind::AgentSpawn {
                 agent,
+                tool_use_id: block.get("id").and_then(|id| id.as_str()).map(String::from),
                 prompt_id: None,
             })
         }
@@ -900,6 +959,68 @@ mod tests {
             r#"{"type":"user","timestamp":"2026-01-01T00:00:04.000Z","toolDenialKind":"some-future-kind","message":{"content":[{"type":"tool_result","is_error":true,"content":"Permission for this action was denied"}]}}"#,
         );
         assert_eq!(count_permission_denials(jsonl), 4);
+    }
+
+    #[test]
+    fn an_agent_spawn_carries_the_call_id_that_names_it() {
+        let jsonl = r#"{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","promptId":"p1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"subagent_type":"Explore"}}]}}"#;
+        let records = parse_session(jsonl);
+        let RecordKind::AgentSpawn {
+            agent,
+            tool_use_id,
+            prompt_id,
+        } = &records[0].kind
+        else {
+            panic!("expected an agent spawn, got {:?}", records[0].kind);
+        };
+        assert_eq!(agent, "Explore");
+        assert_eq!(tool_use_id.as_deref(), Some("toolu_1"));
+        assert_eq!(prompt_id.as_deref(), Some("p1"));
+    }
+
+    #[test]
+    fn a_sidecar_names_the_agent_type_and_the_call_that_spawned_it() {
+        let json = r#"{"agentType":"Explore","description":"look around","toolUseId":"toolu_1","spawnDepth":2,"model":"sonnet","parentAgentId":"a1","newField":"ignored"}"#;
+        assert_eq!(
+            parse_subagent_sidecar(json),
+            Some(SubagentSidecar {
+                agent_type: Some("Explore".into()),
+                tool_use_id: Some("toolu_1".into()),
+                parent_agent_id: Some("a1".into()),
+                spawn_depth: Some(2),
+                model: Some("sonnet".into()),
+            })
+        );
+    }
+
+    #[test]
+    fn a_sidecar_missing_every_known_field_still_parses() {
+        // Forward compatibility: a renamed or dropped upstream field must not
+        // fail the whole run, only leave that fact unknown.
+        assert_eq!(
+            parse_subagent_sidecar("{}"),
+            Some(SubagentSidecar::default())
+        );
+        assert_eq!(parse_subagent_sidecar("not json"), None);
+    }
+
+    #[test]
+    fn a_subagent_id_comes_from_its_file_name() {
+        assert_eq!(subagent_id_from_file_name("agent-a1b2c3"), "a1b2c3");
+    }
+
+    #[test]
+    fn subagent_files_are_laid_out_beside_the_main_transcript() {
+        let transcript = Path::new("/tmp/example/projects/slug/session.jsonl");
+        let dir = subagents_dir(transcript);
+        assert_eq!(
+            dir,
+            Path::new("/tmp/example/projects/slug/session/subagents")
+        );
+        assert_eq!(
+            subagent_sidecar_path(&dir.join("agent-a1b2c3.jsonl")),
+            dir.join("agent-a1b2c3.meta.json")
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,13 +14,15 @@ use crate::adapter::config::{
 };
 use crate::adapter::transcript::{
     count_permission_denials, extract_prompt_pointers, extract_tool_errors, extract_work_events,
-    parse_session, session_cwd, subagent_prompt_id,
+    parse_session, parse_subagent_sidecar, session_cwd, subagent_id_from_file_name,
+    subagent_prompt_id, subagent_sidecar_path, subagents_dir,
 };
 use crate::core::bucket::{Bucket, JST_OFFSET_SECS, bucket_label};
 use crate::core::friction::ErrorCategory;
 use crate::core::optimize as optimize_mod;
 use crate::core::scope::{ScopeFilter, split_friction};
 use crate::core::span::{DEFAULT_IDLE_GAP_MS, SessionStart, extract_spans, session_start};
+use crate::core::subagent::{SubagentRun, link_runs};
 use crate::core::surface::{
     LoadMode, Scope, StartupSavings, Surface, Wedge, classify_wedge, is_usage_measurable,
     on_demand_tokens, startup_savings,
@@ -601,6 +603,15 @@ fn collect_findings(store: &Store) -> Result<optimize_mod::Findings> {
         main_out: store.skill_usage()?.iter().map(|r| r.out_tokens).sum(),
         sub_tokens,
         sub_agents,
+        agents: store
+            .subagent_by_agent()?
+            .into_iter()
+            .map(|row| optimize_mod::AgentCost {
+                agent: row.agent,
+                runs: row.runs,
+                out_tokens: row.out_tokens,
+            })
+            .collect(),
         floor,
         config_tokens: if floor > 0 {
             store.always_on_config_tokens()?
@@ -914,6 +925,40 @@ fn doctor(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resu
             fmt_tokens(f.sub_tokens),
             f.sub_agents
         );
+        warn_missing_agent_split(f.sub_tokens, f.agents.is_empty());
+        // Name the agents behind that second figure — it is usually the larger
+        // one, and "which agent" is the actionable half of it.
+        let top: Vec<String> = f
+            .agents
+            .iter()
+            .take(3)
+            .map(|a| {
+                format!(
+                    "{} {} ({} run{})",
+                    a.label(),
+                    fmt_tokens(a.out_tokens),
+                    a.runs,
+                    if a.runs == 1 { "" } else { "s" }
+                )
+            })
+            .collect();
+        if !top.is_empty() {
+            println!(
+                "  Most of that subagent output: {}. Full split: {}",
+                top.join(", "),
+                style.command("cclens usage")
+            );
+        }
+        // Never truncate silently (reporting honesty, cli.md).
+        if f.agents.len() > top.len() {
+            println!(
+                "  {}",
+                style.dim(&format!(
+                    "… and {} more agent type(s) not shown",
+                    f.agents.len() - top.len()
+                ))
+            );
+        }
     }
 
     // ---- CONFIG WORTH PRUNING: installed-but-dead weight, by owner. ---------
@@ -1547,18 +1592,19 @@ fn run_analyze(projects: Option<PathBuf>, db: &Path) -> Result<AnalyzeStats> {
         let records = parse_session(&text);
         let mut spans = extract_spans(&records, DEFAULT_IDLE_GAP_MS);
         let usage = extract_usage_events(&records);
-        let subagents = subagent_costs(&transcript);
-        attribute_subagents(&mut spans, &subagents);
-        let sub_tokens: i64 = subagents.iter().map(|(_, tokens)| *tokens as i64).sum();
+        let runs = subagent_runs(&transcript);
+        attribute_subagents(&mut spans, &runs);
+        let sub_tokens: i64 = runs.iter().map(|run| run.out_tokens as i64).sum();
         let root = session_cwd(&text).map(|cwd| normalize_root(&cwd));
         let meta = session_meta(
             &transcript,
             root.unwrap_or_default(),
             sub_tokens,
-            subagents.len() as i64,
+            runs.len() as i64,
             session_start(&records),
         );
         store.ingest_session(&meta, &spans, &usage)?;
+        store.ingest_subagent_runs(&meta.id, &meta.source_path, &runs)?;
         let prompts: Vec<(usize, i64, &str)> = extract_prompt_pointers(&text)
             .into_iter()
             .map(|(line, ts, behavior)| (line, ts, behavior.label()))
@@ -1653,6 +1699,27 @@ fn open_for_read(db: &Path, frozen: bool) -> Result<Store> {
     Ok(store)
 }
 
+/// Warn when a report knows a subagent total but not its per-agent split.
+///
+/// A store written before runs were extracted keeps its session totals, and
+/// `--frozen` skips the refresh that would fill the split in — so for that one
+/// read the per-agent rows sum to zero against a nonzero total. Reporting the
+/// gap is the store's contract; printing the total as if nothing were missing
+/// is the substitution it forbids (`docs/specs/storage.md`). It goes to stderr
+/// with the other staleness signals, so piped stdout and `--format json` stay
+/// clean.
+fn warn_missing_agent_split(sub_tokens: i64, agents_empty: bool) {
+    if sub_tokens > 0 && agents_empty {
+        eprintln!(
+            "{}",
+            Style::stderr().warn(
+                "store: per-agent subagent split unavailable (store predates it) \
+                 — run `cclens analyze` (or drop --frozen) to fill it in"
+            )
+        );
+    }
+}
+
 /// Print a freshness line to stderr — dimmed context normally, highlighted
 /// when it carries a staleness hint the user should act on.
 fn eprint_freshness(line: &str) {
@@ -1736,27 +1803,58 @@ fn normalize_root(cwd: &str) -> String {
     cwd.to_string()
 }
 
-/// The `(prompt_id, output_tokens)` of each of a session's subagent transcripts,
-/// found at `<sessionId>/subagents/agent-*.jsonl` beside the main transcript. A
-/// subagent missing a prompt id gets an empty key (it matches no span and stays
-/// in the session total only).
-fn subagent_costs(transcript: &Path) -> Vec<(String, u64)> {
-    let subagents_dir = transcript.with_extension("").join("subagents");
-    let Ok(entries) = fs::read_dir(&subagents_dir) else {
+/// Every subagent run of a session, read from `<sessionId>/subagents/` beside
+/// the main transcript: `agent-<agentId>.jsonl` holds the run's cost, and its
+/// `.meta.json` sidecar names the agent type and the call that spawned it.
+///
+/// Runs come back linked (`link_runs`), so a nested run already knows the
+/// main-thread spawn its tree started at. A run whose sidecar is missing keeps
+/// an unknown agent type and only the turn-level join key — it still counts,
+/// with the gap visible, rather than being guessed at or dropped.
+fn subagent_runs(transcript: &Path) -> Vec<SubagentRun> {
+    let Ok(entries) = fs::read_dir(subagents_dir(transcript)) else {
         return Vec::new();
     };
-    let mut costs = Vec::new();
+    let mut runs = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "jsonl")
-            && let Ok(text) = fs::read_to_string(&path)
-        {
-            let prompt_id = subagent_prompt_id(&text).unwrap_or_default();
-            let tokens = output_tokens(&parse_session(&text));
-            costs.push((prompt_id, tokens));
+        if path.extension().is_none_or(|ext| ext != "jsonl") {
+            continue;
         }
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let sidecar = fs::read_to_string(subagent_sidecar_path(&path))
+            .ok()
+            .and_then(|json| parse_subagent_sidecar(&json))
+            .unwrap_or_default();
+        let records = parse_session(&text);
+        runs.push(SubagentRun {
+            agent: sidecar.agent_type,
+            agent_id: path
+                .file_stem()
+                .map(|stem| subagent_id_from_file_name(&stem.to_string_lossy()))
+                .unwrap_or_default(),
+            run_path: path.display().to_string(),
+            tool_use_id: sidecar.tool_use_id,
+            parent_agent_id: sidecar.parent_agent_id,
+            spawn_depth: sidecar.spawn_depth.unwrap_or(1),
+            model: sidecar.model,
+            prompt_id: subagent_prompt_id(&text),
+            out_tokens: output_tokens(&records),
+            started_epoch_ms: records.first().map(|r| r.timestamp_ms).unwrap_or_default(),
+            root_tool_use_id: None,
+        });
     }
-    costs
+    // Directory order is filesystem-dependent; spawn order is not. Sorting keeps
+    // one session's ingest byte-identical across machines and re-runs.
+    runs.sort_by(|a, b| {
+        a.started_epoch_ms
+            .cmp(&b.started_epoch_ms)
+            .then_with(|| a.agent_id.cmp(&b.agent_id))
+    });
+    link_runs(&mut runs);
+    runs
 }
 
 fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()> {
@@ -1774,6 +1872,11 @@ fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()
     // the per-skill table.
     let main_out: i64 = skills.iter().map(|row| row.out_tokens).sum();
     let (sub_tokens, sub_agents) = store.subagent_totals()?;
+    let agents = store.subagent_by_agent()?;
+    // Ahead of the format branches: a machine consumer reading an empty `agents`
+    // beside a nonzero total needs the reason as much as a human does, and it
+    // goes to stderr precisely so it can be given to both.
+    warn_missing_agent_split(sub_tokens, agents.is_empty());
     if format == Format::Json {
         return emit_json(&serde_json::json!({
             "tokens": {
@@ -1781,22 +1884,54 @@ fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()
                 "sub_tokens": sub_tokens,
                 "sub_agents": sub_agents,
             },
+            "agents": agents,
             "skills": skills,
         }));
     }
-    if skills.is_empty() {
+    // A subagent total with neither table behind it is not "nothing happened" —
+    // it is a store whose per-agent split has not been extracted yet, and saying
+    // "no usage" there would be false.
+    if skills.is_empty() && agents.is_empty() && sub_tokens == 0 {
         println!("no skill usage found — run `cclens analyze` first");
         return Ok(());
     }
     preamble(
         format,
-        "How often each skill ran and what it cost: output tokens written, context\n\
-         growth while it ran, and wall-clock seconds. Most-invoked first.",
+        "What ran and what it cost. First the subagent bill per agent type\n\
+         (costliest first), then how often each skill ran — output tokens written,\n\
+         context growth while it ran, and wall-clock seconds (most-invoked first).\n\
+         A section with nothing to show is omitted.",
     );
     println!(
         "tokens: main-thread skill output {main_out}, subagents {sub_tokens} ({sub_agents} agents)\n"
     );
 
+    // The subagent figure is usually the larger one, so break it down by agent
+    // type before the per-skill table: a spawn count alone cannot tell an
+    // expensive agent from a cheap one that runs often.
+    if !agents.is_empty() {
+        let rows: Vec<Vec<String>> = agents
+            .iter()
+            .map(|row| {
+                vec![
+                    row.agent.clone().unwrap_or_else(|| "(unknown)".to_string()),
+                    row.runs.to_string(),
+                    row.out_tokens.to_string(),
+                ]
+            })
+            .collect();
+        render(
+            &["agent", "runs", "out tokens"],
+            &[Align::Left, Align::Right, Align::Right],
+            &rows,
+            format,
+        );
+        println!();
+    }
+
+    if skills.is_empty() {
+        return Ok(());
+    }
     let rows: Vec<Vec<String>> = skills
         .iter()
         .map(|row| {

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,6 +9,7 @@ pub mod path;
 pub mod prompt;
 pub mod scope;
 pub mod span;
+pub mod subagent;
 pub mod surface;
 pub mod thrash;
 pub mod usage;

--- a/src/core/optimize.rs
+++ b/src/core/optimize.rs
@@ -17,6 +17,9 @@ pub struct Findings {
     pub main_out: i64,
     pub sub_tokens: i64,
     pub sub_agents: i64,
+    /// The subagent total broken out per agent type, costliest first — which
+    /// agent configurations that total actually paid for.
+    pub agents: Vec<AgentCost>,
     /// Empirical always-on floor; 0 means unknown (section omitted).
     pub floor: i64,
     /// Global always-on config tokens (project config is per-project).
@@ -76,6 +79,23 @@ pub struct FrictionCat {
     pub projects: usize,
     pub by_tool: Vec<(String, i64)>,
     pub examples: Vec<String>,
+}
+
+/// One agent type's share of the subagent bill: how often it ran and what its
+/// runs wrote. `agent` is the type's name, or `None` for runs whose type the
+/// transcript did not record.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentCost {
+    pub agent: Option<String>,
+    pub runs: i64,
+    pub out_tokens: i64,
+}
+
+impl AgentCost {
+    /// The name to print — never a blank cell for an unrecorded type.
+    pub fn label(&self) -> &str {
+        self.agent.as_deref().unwrap_or("(unknown)")
+    }
 }
 
 /// A configuration surface referenced in the config sections. The two costs are
@@ -150,6 +170,15 @@ the failing path/file — including any worktree segment like `/.wt/`, so a work
 split is a `WHERE excerpt LIKE …` away), `tool` = the tool that produced it, `target` = the \
 file_path it edited or command it ran (use this when the error text omits the path, e.g. \
 edit-precondition's \"File has not been read yet\"). `project` = the session's cwd slug.
+    - subagent_runs(session_id, agent, spawn_depth, model, out_tokens, run_path, …): one row per \
+subagent execution. `agent` = the agent type that ran (NULL when the transcript did not record \
+it), `out_tokens` = what that run wrote, `spawn_depth` = 1 for a main-thread spawn and 2+ for an \
+agent spawned by an agent. Group by `agent` to see which agent configurations the subagent bill \
+paid for. To reach the main-thread spawn a run came from, join \
+`events.target = subagent_runs.root_tool_use_id` — that works at every depth, because a nested \
+run's own `tool_use_id` names a call inside its parent subagent's transcript, which has no \
+`events` row at all (only main transcripts produce events). Joining on `tool_use_id` therefore \
+silently drops every nested run.
     - sessions(id, project, slug, source_path, started_at, …) and events(session_id, kind, \
 surface_id, source, model, started_epoch, …) hold everything else (run `cclens sql \
 \"SELECT sql FROM sqlite_master\"` to see all of it). Confirm an encoding by sampling the \
@@ -191,6 +220,16 @@ pub fn render_briefing(f: &Findings, filter: &ScopeFilter) -> String {
             "- Subagents: {} ({} agents)\n",
             f.sub_tokens, f.sub_agents
         ));
+        // Which agent types that total paid for — the split two agents with
+        // similar spawn counts and very different output can only show here.
+        for agent in &f.agents {
+            out.push_str(&format!(
+                "  - {}: {} over {} run(s)\n",
+                agent.label(),
+                agent.out_tokens,
+                agent.runs
+            ));
+        }
 
         if f.floor > 0 {
             let residual = (f.floor - f.config_tokens).max(0);
@@ -437,6 +476,18 @@ mod tests {
             main_out: 8_000_000,
             sub_tokens: 1_800_000,
             sub_agents: 300,
+            agents: vec![
+                AgentCost {
+                    agent: Some("general-purpose".to_string()),
+                    runs: 220,
+                    out_tokens: 1_500_000,
+                },
+                AgentCost {
+                    agent: None,
+                    runs: 80,
+                    out_tokens: 300_000,
+                },
+            ],
             floor: 35_000,
             config_tokens: 2_000,
             friction_global: vec![FrictionCat {
@@ -644,6 +695,16 @@ mod tests {
         assert!(brief.contains("cd is 53% of Bash calls"));
         assert!(brief.contains("cargo: 80"));
         assert!(brief.contains("SKILL.md edited 25x within 7m40s"));
+    }
+
+    #[test]
+    fn briefing_splits_the_subagent_total_by_agent_type() {
+        let brief = render_briefing(&findings(), &ScopeFilter::All);
+        assert!(brief.contains("- Subagents: 1800000 (300 agents)"));
+        assert!(brief.contains("  - general-purpose: 1500000 over 220 run(s)"));
+        // A run whose agent type was never recorded is shown as unknown, not
+        // dropped — the per-agent rows must still sum to the total.
+        assert!(brief.contains("  - (unknown): 300000 over 80 run(s)"));
     }
 
     #[test]

--- a/src/core/span.rs
+++ b/src/core/span.rs
@@ -31,10 +31,12 @@ pub enum RecordKind {
         model: String,
     },
     /// A subagent spawn (the `Agent` tool) — usage of an `agent` surface. The
-    /// `prompt_id` is the spawning turn's id, the join key to the subagent's
-    /// transcript for cost attribution (`docs/specs/events.md`).
+    /// two ids are the join keys to the subagent's own transcript for cost
+    /// attribution: `tool_use_id` names this exact call, `prompt_id` only the
+    /// turn it happened in (`docs/specs/events.md`).
     AgentSpawn {
         agent: String,
+        tool_use_id: Option<String>,
         prompt_id: Option<String>,
     },
     /// A tool invocation by name — used to detect MCP tool usage.
@@ -48,6 +50,18 @@ pub enum RecordKind {
 pub struct Record {
     pub timestamp_ms: i64,
     pub kind: RecordKind,
+}
+
+/// A subagent spawn observed inside a span's window, reduced to the keys
+/// attribution joins on (`docs/specs/events.md`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpawnRef {
+    /// The `Agent` tool call's id: exact, so a subagent that names it lands on
+    /// exactly one span.
+    pub tool_use_id: Option<String>,
+    /// The spawning turn's id: shared by every spawn in the turn, so it can only
+    /// narrow a subagent to a set of candidate spans.
+    pub prompt_id: Option<String>,
 }
 
 /// A single extracted skill execution with its rolled-up cost metrics.
@@ -66,9 +80,9 @@ pub struct Span {
     /// sibling skill, or idle gap followed) — its `duration_sec` is a lower
     /// bound (`docs/specs/events.md`).
     pub is_trailing: bool,
-    /// Prompt ids of the subagents this span spawned — the join key for
+    /// The subagent spawns inside this span's window — the join keys for
     /// attribution; not persisted.
-    pub agent_prompt_ids: Vec<String>,
+    pub spawns: Vec<SpawnRef>,
     /// Subagent cost attributed to this span (filled by `attribute_subagents`).
     pub sub_tokens: u64,
     pub sub_agent_count: u32,
@@ -173,7 +187,7 @@ fn roll_up(
     let mut prompt_sizes = Vec::new();
     let mut out_tokens = 0;
     let mut models = Vec::new();
-    let mut agent_prompt_ids = Vec::new();
+    let mut spawns = Vec::new();
     for record in window {
         match &record.kind {
             RecordKind::Assistant {
@@ -186,9 +200,13 @@ fn roll_up(
                 models.push(model.as_str());
             }
             RecordKind::AgentSpawn {
-                prompt_id: Some(prompt_id),
+                tool_use_id,
+                prompt_id,
                 ..
-            } => agent_prompt_ids.push(prompt_id.clone()),
+            } => spawns.push(SpawnRef {
+                tool_use_id: tool_use_id.clone(),
+                prompt_id: prompt_id.clone(),
+            }),
             _ => {}
         }
     }
@@ -204,7 +222,7 @@ fn roll_up(
         ctx_peak: prompt_sizes.iter().copied().max().unwrap_or(0),
         model: representative_model(&models).map(String::from),
         is_trailing,
-        agent_prompt_ids,
+        spawns,
         sub_tokens: 0,
         sub_agent_count: 0,
         sub_tokens_estimated: false,
@@ -395,6 +413,40 @@ mod tests {
         assert_eq!(span.ctx_start, 100);
         assert_eq!(span.ctx_peak, 250);
         assert_eq!(span.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn a_span_records_both_join_keys_of_the_spawns_in_its_window() {
+        let records = [
+            at(1000, skill("code-review")),
+            at(
+                2000,
+                RecordKind::AgentSpawn {
+                    agent: "Explore".into(),
+                    tool_use_id: Some("toolu_1".into()),
+                    prompt_id: Some("p1".into()),
+                },
+            ),
+            at(3000, RecordKind::HumanTurn),
+            at(
+                4000,
+                RecordKind::AgentSpawn {
+                    agent: "Explore".into(),
+                    tool_use_id: Some("toolu_2".into()),
+                    prompt_id: Some("p2".into()),
+                },
+            ),
+        ];
+
+        let span = &extract_spans(&records, DEFAULT_IDLE_GAP_MS)[0];
+
+        assert_eq!(
+            span.spawns,
+            vec![SpawnRef {
+                tool_use_id: Some("toolu_1".into()),
+                prompt_id: Some("p1".into()),
+            }]
+        );
     }
 
     #[test]

--- a/src/core/subagent.rs
+++ b/src/core/subagent.rs
@@ -1,0 +1,146 @@
+//! Subagent runs: one execution of one agent type, with its own output cost.
+//!
+//! A run is what makes "which agent types consumed those tokens?" answerable —
+//! the session-level subagent total says only *how much*. Runs also form a tree
+//! (an agent can spawn agents), and only the tree's root was spawned from the
+//! main thread, so `link_runs` resolves every run to that root before any
+//! per-span attribution. See `docs/specs/events.md`.
+
+/// One subagent execution: what ran, what it cost, and the keys that link it
+/// back to the spawn that started it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubagentRun {
+    /// The agent type that ran (`Explore`, a custom agent's name). `None` when
+    /// the transcript's sidecar is missing — the run is then counted but not
+    /// attributed to a type, never guessed.
+    pub agent: Option<String>,
+    /// The run's own id, unique within the session; the key children name.
+    pub agent_id: String,
+    /// The subagent's own transcript, kept so a report can point at the run
+    /// itself rather than only at the session that spawned it.
+    pub run_path: String,
+    /// The spawning `Agent` tool call's id — the exact join key back to the
+    /// spawning event (`docs/specs/session-format.md`). `None` without a sidecar.
+    pub tool_use_id: Option<String>,
+    /// The run's parent run, for a subagent spawned by a subagent.
+    pub parent_agent_id: Option<String>,
+    /// 1 for a main-thread spawn, 2+ for a nested one.
+    pub spawn_depth: u32,
+    pub model: Option<String>,
+    /// The spawning turn's id — the coarse fallback join key when no sidecar
+    /// names the spawning call.
+    pub prompt_id: Option<String>,
+    pub out_tokens: u64,
+    pub started_epoch_ms: i64,
+    /// The `tool_use_id` of the main-thread spawn that started this run's tree,
+    /// filled by [`link_runs`]. Equals `tool_use_id` for a depth-1 run.
+    pub root_tool_use_id: Option<String>,
+}
+
+/// Resolve each run's `root_tool_use_id` by walking `parent_agent_id` up to the
+/// run that was spawned from the main thread.
+///
+/// A nested run's own `tool_use_id` names a call inside its *parent's*
+/// transcript, which no main-thread span contains — so attributing a subtree's
+/// cost to the main-thread work that caused it requires the root's id, not the
+/// run's own. A run whose chain is broken (a missing parent, or a cycle in
+/// malformed input) keeps `None` and stays unattributed rather than being
+/// charged to an arbitrary spawn.
+pub fn link_runs(runs: &mut [SubagentRun]) {
+    let parents: Vec<(String, Option<String>, Option<String>)> = runs
+        .iter()
+        .map(|run| {
+            (
+                run.agent_id.clone(),
+                run.parent_agent_id.clone(),
+                run.tool_use_id.clone(),
+            )
+        })
+        .collect();
+
+    let roots: Vec<Option<String>> = (0..parents.len())
+        .map(|start| {
+            let mut current = start;
+            let mut hops = 0;
+            loop {
+                let (_, parent, tool_use_id) = &parents[current];
+                let Some(parent) = parent else {
+                    break tool_use_id.clone();
+                };
+                // Bound the walk so a cycle in malformed input cannot hang analyze.
+                hops += 1;
+                if hops > parents.len() {
+                    break None;
+                }
+                match parents.iter().position(|(id, _, _)| id == parent) {
+                    Some(next) => current = next,
+                    None => break None,
+                }
+            }
+        })
+        .collect();
+
+    for (run, root) in runs.iter_mut().zip(roots) {
+        run.root_tool_use_id = root;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(agent_id: &str, parent: Option<&str>, tool_use_id: Option<&str>) -> SubagentRun {
+        SubagentRun {
+            agent: Some("Explore".into()),
+            agent_id: agent_id.into(),
+            run_path: format!("/tmp/example/subagents/agent-{agent_id}.jsonl"),
+            tool_use_id: tool_use_id.map(String::from),
+            parent_agent_id: parent.map(String::from),
+            spawn_depth: 1,
+            model: None,
+            prompt_id: None,
+            out_tokens: 0,
+            started_epoch_ms: 0,
+            root_tool_use_id: None,
+        }
+    }
+
+    #[test]
+    fn a_top_level_run_is_its_own_root() {
+        let mut runs = vec![run("a1", None, Some("toolu_1"))];
+        link_runs(&mut runs);
+        assert_eq!(runs[0].root_tool_use_id.as_deref(), Some("toolu_1"));
+    }
+
+    #[test]
+    fn a_nested_run_resolves_to_the_main_thread_spawn_that_started_its_tree() {
+        let mut runs = vec![
+            run("a1", None, Some("toolu_1")),
+            run("a2", Some("a1"), Some("toolu_2")),
+            run("a3", Some("a2"), Some("toolu_3")),
+        ];
+        link_runs(&mut runs);
+        let roots: Vec<_> = runs.iter().map(|r| r.root_tool_use_id.as_deref()).collect();
+        assert_eq!(
+            roots,
+            vec![Some("toolu_1"), Some("toolu_1"), Some("toolu_1")]
+        );
+    }
+
+    #[test]
+    fn a_run_whose_parent_is_missing_stays_unrooted() {
+        let mut runs = vec![run("a2", Some("gone"), Some("toolu_2"))];
+        link_runs(&mut runs);
+        assert_eq!(runs[0].root_tool_use_id, None);
+    }
+
+    #[test]
+    fn a_parent_cycle_terminates_without_a_root() {
+        let mut runs = vec![
+            run("a1", Some("a2"), Some("toolu_1")),
+            run("a2", Some("a1"), Some("toolu_2")),
+        ];
+        link_runs(&mut runs);
+        assert!(runs.iter().all(|r| r.root_tool_use_id.is_none()));
+    }
+}

--- a/src/core/usage.rs
+++ b/src/core/usage.rs
@@ -5,6 +5,7 @@
 //! `docs/specs/events.md`, `surfaces.md`.
 
 use crate::core::span::{Record, RecordKind, Span};
+use crate::core::subagent::SubagentRun;
 
 /// One surface-usage occurrence, keyed for the catalog×usage join.
 #[derive(Debug, Clone, PartialEq)]
@@ -12,6 +13,9 @@ pub struct UsageEvent {
     pub surface_kind: String,
     pub surface_id: String,
     pub started_epoch_ms: i64,
+    /// For an agent spawn, the `Agent` call's id — persisted so a stored spawn
+    /// joins the subagent run it started. `None` for every other surface.
+    pub tool_use_id: Option<String>,
 }
 
 /// Total assistant output tokens across a record stream — used to sum a
@@ -26,26 +30,50 @@ pub fn output_tokens(records: &[Record]) -> u64 {
         .sum()
 }
 
-/// Attribute subagent costs to the spans that spawned them, joined by prompt id.
+/// Attribute subagent costs to the spans that spawned them.
 ///
-/// `subagents` is `(prompt_id, output_tokens)` per subagent transcript. A
-/// subagent is attributed to every span whose `agent_prompt_ids` contains its
-/// prompt id; when more than one span competes, its tokens are split equally and
-/// those spans are flagged estimated (`docs/specs/events.md`). A subagent with
-/// no matching span is left to the session-level total.
-pub fn attribute_subagents(spans: &mut [Span], subagents: &[(String, u64)]) {
-    for (prompt_id, tokens) in subagents {
-        let claimants: Vec<usize> = spans
-            .iter()
-            .enumerate()
-            .filter(|(_, span)| span.agent_prompt_ids.iter().any(|id| id == prompt_id))
-            .map(|(index, _)| index)
-            .collect();
+/// The join is tried at two precisions, and only falls back when it must
+/// (`docs/specs/events.md`):
+///
+/// 1. **By spawn call.** A run whose tree was rooted at a known `Agent` call
+///    lands on the one span containing that call — spans do not overlap, so
+///    this is exact and never flagged estimated. Nested runs resolve through
+///    their root (`core::subagent::link_runs`), so a subtree's whole cost is
+///    charged to the main-thread work that started it.
+/// 2. **By turn.** Only for a run that carries no call id at all (an older
+///    transcript with no sidecar). The run is then claimed by every span that
+///    spawned anything in the same turn; when more than one competes they split
+///    its tokens equally and are flagged estimated.
+///
+/// Once a run carries a call id, the turn join is never used for it — not when
+/// its rooted call is in no span (the root says which call spawned it, so no
+/// span containing that call means it was spawned outside every span), and not
+/// when its parent chain is broken (`link_runs` left it unrooted). Falling back
+/// in either case would charge it to whichever unrelated span happened to spawn
+/// something in the same turn, which is the error the call id exists to prevent.
+///
+/// A run matching no span is left to the session-level total, which is exact.
+pub fn attribute_subagents(spans: &mut [Span], runs: &[SubagentRun]) {
+    for run in runs {
+        let (claimants, estimated): (Vec<usize>, bool) = match run {
+            _ if run.root_tool_use_id.is_some() => {
+                (claim_by_spawn(spans, run).into_iter().collect(), false)
+            }
+            // Unrooted despite having a call id: its chain is broken, not absent.
+            _ if run.tool_use_id.is_some() => (Vec::new(), false),
+            _ => {
+                let claimants = claim_by_turn(spans, run);
+                let estimated = claimants.len() > 1;
+                (claimants, estimated)
+            }
+        };
         if claimants.is_empty() {
             continue;
         }
-        let estimated = claimants.len() > 1;
-        let share = tokens / claimants.len() as u64;
+        // Integer division drops the remainder on purpose: a split figure is
+        // already flagged estimated, and the authoritative total sums the runs
+        // themselves, so nothing that must balance depends on this.
+        let share = run.out_tokens / claimants.len() as u64;
         for index in claimants {
             spans[index].sub_tokens += share;
             spans[index].sub_agent_count += 1;
@@ -54,20 +82,51 @@ pub fn attribute_subagents(spans: &mut [Span], subagents: &[(String, u64)]) {
     }
 }
 
+/// The single span containing the `Agent` call this run's tree was rooted at.
+fn claim_by_spawn(spans: &[Span], run: &SubagentRun) -> Option<usize> {
+    let root = run.root_tool_use_id.as_deref()?;
+    spans.iter().position(|span| {
+        span.spawns
+            .iter()
+            .any(|spawn| spawn.tool_use_id.as_deref() == Some(root))
+    })
+}
+
+/// Every span that spawned a subagent in the same turn as this run.
+fn claim_by_turn(spans: &[Span], run: &SubagentRun) -> Vec<usize> {
+    let Some(prompt_id) = run.prompt_id.as_deref() else {
+        return Vec::new();
+    };
+    spans
+        .iter()
+        .enumerate()
+        .filter(|(_, span)| {
+            span.spawns
+                .iter()
+                .any(|spawn| spawn.prompt_id.as_deref() == Some(prompt_id))
+        })
+        .map(|(index, _)| index)
+        .collect()
+}
+
 /// Extract agent-spawn and MCP-tool usage events from the record stream.
 pub fn extract_usage_events(records: &[Record]) -> Vec<UsageEvent> {
     records
         .iter()
         .filter_map(|record| match &record.kind {
-            RecordKind::AgentSpawn { agent, .. } => Some(UsageEvent {
+            RecordKind::AgentSpawn {
+                agent, tool_use_id, ..
+            } => Some(UsageEvent {
                 surface_kind: "agent".to_string(),
                 surface_id: agent.clone(),
                 started_epoch_ms: record.timestamp_ms,
+                tool_use_id: tool_use_id.clone(),
             }),
             RecordKind::ToolUse { tool } => mcp_server_of(tool).map(|server| UsageEvent {
                 surface_kind: "mcp_server".to_string(),
                 surface_id: server,
                 started_epoch_ms: record.timestamp_ms,
+                tool_use_id: None,
             }),
             _ => None,
         })
@@ -86,6 +145,7 @@ fn mcp_server_of(tool: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::span::SpawnRef;
 
     fn at(timestamp_ms: i64, kind: RecordKind) -> Record {
         Record { timestamp_ms, kind }
@@ -97,6 +157,7 @@ mod tests {
             100,
             RecordKind::AgentSpawn {
                 agent: "Explore".into(),
+                tool_use_id: Some("toolu_1".into()),
                 prompt_id: None,
             },
         )];
@@ -107,6 +168,7 @@ mod tests {
                 surface_kind: "agent".into(),
                 surface_id: "Explore".into(),
                 started_epoch_ms: 100,
+                tool_use_id: Some("toolu_1".into()),
             }]
         );
     }
@@ -146,7 +208,8 @@ mod tests {
         assert!(extract_usage_events(&records).is_empty());
     }
 
-    fn span_with(skill: &str, agent_prompt_ids: &[&str]) -> Span {
+    /// A span whose window contains one spawn per `(tool_use_id, prompt_id)`.
+    fn span_with(skill: &str, spawns: &[(Option<&str>, &str)]) -> Span {
         Span {
             skill: skill.to_string(),
             source: crate::core::span::Source::Tool,
@@ -158,26 +221,96 @@ mod tests {
             ctx_peak: 0,
             model: None,
             is_trailing: false,
-            agent_prompt_ids: agent_prompt_ids.iter().map(|s| s.to_string()).collect(),
+            spawns: spawns
+                .iter()
+                .map(|(tool_use_id, prompt_id)| SpawnRef {
+                    tool_use_id: tool_use_id.map(String::from),
+                    prompt_id: Some(prompt_id.to_string()),
+                })
+                .collect(),
             sub_tokens: 0,
             sub_agent_count: 0,
             sub_tokens_estimated: false,
         }
     }
 
+    /// A run rooted at `root` (the spawn call that started its tree), spawned in
+    /// turn `prompt_id`.
+    fn run(root: Option<&str>, prompt_id: &str, out_tokens: u64) -> SubagentRun {
+        SubagentRun {
+            agent: Some("Explore".into()),
+            agent_id: "a1".into(),
+            run_path: "/tmp/example/subagents/agent-a1.jsonl".into(),
+            tool_use_id: root.map(String::from),
+            parent_agent_id: None,
+            spawn_depth: 1,
+            model: None,
+            prompt_id: Some(prompt_id.to_string()),
+            out_tokens,
+            started_epoch_ms: 0,
+            root_tool_use_id: root.map(String::from),
+        }
+    }
+
     #[test]
     fn a_subagent_is_attributed_to_the_span_that_spawned_it() {
-        let mut spans = vec![span_with("code-review", &["p1"])];
-        attribute_subagents(&mut spans, &[("p1".to_string(), 500)]);
+        let mut spans = vec![span_with("code-review", &[(Some("toolu_1"), "p1")])];
+        attribute_subagents(&mut spans, &[run(Some("toolu_1"), "p1", 500)]);
         assert_eq!(spans[0].sub_tokens, 500);
         assert_eq!(spans[0].sub_agent_count, 1);
         assert!(!spans[0].sub_tokens_estimated);
     }
 
     #[test]
+    fn the_spawn_call_settles_which_of_two_spans_in_a_turn_pays() {
+        // Both spans spawned in turn p1, so the turn alone cannot tell them
+        // apart — the call id can, exactly and without an estimate.
+        let mut spans = vec![
+            span_with("a", &[(Some("toolu_1"), "p1")]),
+            span_with("b", &[(Some("toolu_2"), "p1")]),
+        ];
+        attribute_subagents(&mut spans, &[run(Some("toolu_2"), "p1", 100)]);
+        assert_eq!(spans[0].sub_tokens, 0);
+        assert_eq!(spans[1].sub_tokens, 100);
+        assert!(!spans[1].sub_tokens_estimated);
+    }
+
+    #[test]
+    fn a_nested_run_is_charged_to_the_span_that_started_its_tree() {
+        let mut spans = vec![span_with("code-review", &[(Some("toolu_1"), "p1")])];
+        let mut nested = run(Some("toolu_1"), "p1", 300);
+        // The nested run's own call lives in its parent's transcript, which no
+        // span contains; only its root links it back to the main thread.
+        nested.tool_use_id = Some("toolu_nested".into());
+        nested.spawn_depth = 2;
+        attribute_subagents(&mut spans, &[nested]);
+        assert_eq!(spans[0].sub_tokens, 300);
+    }
+
+    #[test]
+    fn a_run_whose_parent_chain_is_broken_stays_unattributed() {
+        // It has a call id, so it was not spawned from the main thread — its
+        // parent's transcript is simply missing. The turn join would hand it to
+        // whichever span spawned something in that turn, which is a guess the
+        // call id already rules out.
+        let mut spans = vec![span_with("git-commit", &[(Some("toolu_1"), "p1")])];
+        let mut orphan = run(None, "p1", 100);
+        orphan.tool_use_id = Some("toolu_nested".into());
+        orphan.parent_agent_id = Some("gone".into());
+        orphan.spawn_depth = 2;
+        attribute_subagents(&mut spans, &[orphan]);
+        assert_eq!(spans[0].sub_tokens, 0);
+        assert_eq!(spans[0].sub_agent_count, 0);
+    }
+
+    #[test]
     fn competing_spans_split_equally_and_are_flagged_estimated() {
-        let mut spans = vec![span_with("a", &["p1"]), span_with("b", &["p1"])];
-        attribute_subagents(&mut spans, &[("p1".to_string(), 100)]);
+        // No sidecar named the spawning call, so only the turn is left to join on.
+        let mut spans = vec![
+            span_with("a", &[(None, "p1")]),
+            span_with("b", &[(None, "p1")]),
+        ];
+        attribute_subagents(&mut spans, &[run(None, "p1", 100)]);
         assert_eq!(spans[0].sub_tokens, 50);
         assert_eq!(spans[1].sub_tokens, 50);
         assert!(spans[0].sub_tokens_estimated);
@@ -186,9 +319,21 @@ mod tests {
 
     #[test]
     fn a_subagent_with_no_matching_span_is_left_unattributed() {
-        let mut spans = vec![span_with("a", &["p1"])];
-        attribute_subagents(&mut spans, &[("other".to_string(), 100)]);
+        let mut spans = vec![span_with("a", &[(Some("toolu_1"), "p1")])];
+        attribute_subagents(&mut spans, &[run(Some("toolu_9"), "other", 100)]);
         assert_eq!(spans[0].sub_tokens, 0);
+    }
+
+    #[test]
+    fn a_rooted_run_spawned_outside_every_span_does_not_fall_back_to_the_turn() {
+        // The span spawned its own agent in turn p1; this run was rooted at a
+        // different call, made outside any span in that same turn. Knowing the
+        // call is knowing it was not this span's — the turn must not re-claim it.
+        let mut spans = vec![span_with("git-commit", &[(Some("toolu_1"), "p1")])];
+        attribute_subagents(&mut spans, &[run(Some("toolu_outside"), "p1", 100)]);
+        assert_eq!(spans[0].sub_tokens, 0);
+        assert_eq!(spans[0].sub_agent_count, 0);
+        assert!(!spans[0].sub_tokens_estimated);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::core::span::{SessionStart, Source, Span};
+use crate::core::subagent::SubagentRun;
 use crate::core::surface::Surface;
 use crate::core::thrash::FileEdit;
 use crate::core::usage::UsageEvent;
@@ -23,7 +24,7 @@ const ANALYZER_META_KEY: &str = "analyzer_version";
 /// only way rows behind the incremental-ingest skip get rebuilt. It is not the
 /// crate version: a release that changes no analysis should not force everyone
 /// through a full re-analyze.
-const ANALYZER_VERSION: &str = "1";
+const ANALYZER_VERSION: &str = "2";
 
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS sessions (
@@ -59,6 +60,27 @@ CREATE TABLE IF NOT EXISTS events (
     sub_tokens_estimated INTEGER NOT NULL DEFAULT 0,
     is_trailing          INTEGER NOT NULL DEFAULT 0
 );
+-- One row per subagent execution: which agent type ran, and what its own output
+-- cost. The session total says how much subagent work cost; this says *whose*.
+-- `source_path` is the parent session's transcript — the ingest delete key, as
+-- for events — while `run_path` points at the subagent's own transcript.
+CREATE TABLE IF NOT EXISTS subagent_runs (
+    id                INTEGER PRIMARY KEY,
+    session_id        TEXT NOT NULL,
+    source_path       TEXT NOT NULL,
+    run_path          TEXT NOT NULL,
+    agent             TEXT,
+    agent_id          TEXT NOT NULL,
+    tool_use_id       TEXT,
+    root_tool_use_id  TEXT,
+    parent_agent_id   TEXT,
+    spawn_depth       INTEGER NOT NULL DEFAULT 1,
+    model             TEXT,
+    prompt_id         TEXT,
+    out_tokens        INTEGER NOT NULL DEFAULT 0,
+    started_at        TEXT NOT NULL,
+    started_epoch     INTEGER NOT NULL
+);
 CREATE TABLE IF NOT EXISTS surfaces (
     kind          TEXT NOT NULL,
     id            TEXT NOT NULL,
@@ -92,6 +114,8 @@ CREATE TABLE IF NOT EXISTS ingested_files (
 /// the missing column, and take the whole migration down with it.
 const INDEX_SCHEMA: &str = "
 CREATE INDEX events_by_surface ON events(surface_kind, surface_id);
+CREATE INDEX subagent_runs_by_agent ON subagent_runs(agent);
+CREATE INDEX subagent_runs_by_source ON subagent_runs(source_path);
 ";
 
 /// Views are pure definitions over the tables, declared apart from them for the
@@ -187,6 +211,15 @@ pub struct CatalogEntry {
     pub startup_tokens: Option<i64>,
     pub load_mode: String,
     pub uses: i64,
+}
+
+/// What one agent type cost: how many times it ran and the output tokens those
+/// runs wrote. `agent` is `None` for runs whose type could not be read.
+#[derive(Debug, PartialEq, serde::Serialize)]
+pub struct AgentCost {
+    pub agent: Option<String>,
+    pub runs: i64,
+    pub out_tokens: i64,
 }
 
 /// One skill event's cost, with its UTC start, for time bucketing.
@@ -362,12 +395,14 @@ impl Store {
             } else {
                 "tool_use"
             };
+            // An agent spawn keeps its call id in `target` — the join key to the
+            // subagent run it started (`ingest_subagent_runs`).
             tx.execute(
                 "INSERT INTO events
                    (session_id, source_path, kind, surface_kind, surface_id, source,
                     started_at, started_epoch, duration_sec, out_tokens, ctx_growth,
-                    ctx_start, ctx_peak, model)
-                 VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, 0, 0, 0, 0, 0, NULL)",
+                    ctx_start, ctx_peak, model, target)
+                 VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, ?7, 0, 0, 0, 0, 0, NULL, ?8)",
                 (
                     &session.id,
                     &session.source_path,
@@ -376,6 +411,7 @@ impl Store {
                     &event.surface_id,
                     epoch_ms_to_rfc3339(event.started_epoch_ms),
                     event.started_epoch_ms / 1000,
+                    &event.tool_use_id,
                 ),
             )?;
         }
@@ -412,6 +448,77 @@ impl Store {
                 ),
             )?;
         }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Persist a session's subagent runs, and settle the cost of the spawns that
+    /// started them.
+    ///
+    /// Two rows describe one subagent from opposite sides: the `agent_spawn`
+    /// event is what the main thread *did*, the run is what it *cost*. They are
+    /// joined by the spawn call's id — kept in the event's `target` — so the
+    /// spawn's own `out_tokens` becomes the run's output and its `sub_tokens`
+    /// the output of everything that run spawned in turn. A spawn whose run is
+    /// missing keeps its zeros rather than borrowing another's figures.
+    ///
+    /// Call after `ingest_session`, which inserted those spawn events.
+    pub fn ingest_subagent_runs(
+        &mut self,
+        session_id: &str,
+        source_path: &str,
+        runs: &[SubagentRun],
+    ) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM subagent_runs WHERE source_path = ?1",
+            (source_path,),
+        )?;
+        for run in runs {
+            tx.execute(
+                "INSERT INTO subagent_runs
+                   (session_id, source_path, run_path, agent, agent_id, tool_use_id,
+                    root_tool_use_id, parent_agent_id, spawn_depth, model, prompt_id,
+                    out_tokens, started_at, started_epoch)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                (
+                    session_id,
+                    source_path,
+                    &run.run_path,
+                    &run.agent,
+                    &run.agent_id,
+                    &run.tool_use_id,
+                    &run.root_tool_use_id,
+                    &run.parent_agent_id,
+                    run.spawn_depth,
+                    &run.model,
+                    &run.prompt_id,
+                    run.out_tokens,
+                    epoch_ms_to_rfc3339(run.started_epoch_ms),
+                    run.started_epoch_ms / 1000,
+                ),
+            )?;
+        }
+        tx.execute(
+            // Every subquery is scoped to this transcript. A call id is unique
+            // within a session but nothing guarantees it across sessions, and an
+            // unscoped scalar subquery would silently pick an arbitrary matching
+            // row while the sums added another session's runs on top.
+            "UPDATE events
+                SET out_tokens = COALESCE((SELECT r.out_tokens FROM subagent_runs r
+                                            WHERE r.source_path = events.source_path
+                                              AND r.tool_use_id = events.target), 0),
+                    sub_tokens = COALESCE((SELECT SUM(r.out_tokens) FROM subagent_runs r
+                                            WHERE r.source_path = events.source_path
+                                              AND r.root_tool_use_id = events.target
+                                              AND r.tool_use_id IS NOT events.target), 0),
+                    sub_agent_count = (SELECT COUNT(*) FROM subagent_runs r
+                                        WHERE r.source_path = events.source_path
+                                          AND r.root_tool_use_id = events.target
+                                          AND r.tool_use_id IS NOT events.target)
+              WHERE kind = 'agent_spawn' AND source_path = ?1 AND target IS NOT NULL",
+            (source_path,),
+        )?;
         tx.commit()?;
         Ok(())
     }
@@ -717,6 +824,33 @@ impl Store {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
         Ok(row)
+    }
+
+    /// Subagent output tokens and run count per agent type, costliest first —
+    /// the breakdown behind the session-level subagent total.
+    ///
+    /// Every run counts once, at its own cost, whatever its depth: a nested run
+    /// is the agent that produced those tokens, and rolling it into its parent's
+    /// type would credit the cost to an agent that only delegated. Runs whose
+    /// type is unknown (no sidecar beside the transcript) group under `None`
+    /// rather than being dropped, so the rows still sum to the total.
+    pub fn subagent_by_agent(&self) -> Result<Vec<AgentCost>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT agent, COUNT(*), COALESCE(SUM(out_tokens), 0)
+             FROM subagent_runs
+             GROUP BY agent
+             ORDER BY COALESCE(SUM(out_tokens), 0) DESC, COUNT(*) DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(AgentCost {
+                    agent: row.get(0)?,
+                    runs: row.get(1)?,
+                    out_tokens: row.get(2)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
     }
 
     /// Invocation counts per surface `(kind, id)` across all event kinds — the
@@ -1136,7 +1270,7 @@ mod tests {
             ctx_peak: ctx_growth,
             model: Some("claude-opus-4-7".to_string()),
             is_trailing: false,
-            agent_prompt_ids: Vec::new(),
+            spawns: Vec::new(),
             sub_tokens: 0,
             sub_agent_count: 0,
             sub_tokens_estimated: false,
@@ -1154,6 +1288,182 @@ mod tests {
             sub_agent_count: 0,
             start: None,
         }
+    }
+
+    fn agent_spawn(surface_id: &str, tool_use_id: &str) -> UsageEvent {
+        UsageEvent {
+            surface_kind: "agent".to_string(),
+            surface_id: surface_id.to_string(),
+            started_epoch_ms: 1_700_000_000_000,
+            tool_use_id: Some(tool_use_id.to_string()),
+        }
+    }
+
+    fn subagent_run(agent: &str, agent_id: &str, root: &str, out_tokens: u64) -> SubagentRun {
+        SubagentRun {
+            agent: Some(agent.to_string()),
+            agent_id: agent_id.to_string(),
+            run_path: format!("/tmp/example/subagents/agent-{agent_id}.jsonl"),
+            tool_use_id: Some(format!("toolu_{agent_id}")),
+            parent_agent_id: None,
+            spawn_depth: 1,
+            model: Some("sonnet".to_string()),
+            prompt_id: Some("p1".to_string()),
+            out_tokens,
+            started_epoch_ms: 1_700_000_000_000,
+            root_tool_use_id: Some(root.to_string()),
+        }
+    }
+
+    #[test]
+    fn subagent_cost_rolls_up_per_agent_type() {
+        let mut store = Store::in_memory().unwrap();
+        let s1 = session("s1");
+        store.ingest_session(&s1, &[], &[]).unwrap();
+        store
+            .ingest_subagent_runs(
+                &s1.id,
+                &s1.source_path,
+                &[
+                    subagent_run("Explore", "a1", "toolu_a1", 400),
+                    subagent_run("Explore", "a2", "toolu_a2", 100),
+                    subagent_run("code-writer", "a3", "toolu_a3", 900),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.subagent_by_agent().unwrap(),
+            vec![
+                AgentCost {
+                    agent: Some("code-writer".to_string()),
+                    runs: 1,
+                    out_tokens: 900,
+                },
+                AgentCost {
+                    agent: Some("Explore".to_string()),
+                    runs: 2,
+                    out_tokens: 500,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_spawn_event_takes_the_cost_of_the_run_it_started() {
+        let mut store = Store::in_memory().unwrap();
+        let s1 = session("s1");
+        store
+            .ingest_session(&s1, &[], &[agent_spawn("Explore", "toolu_a1")])
+            .unwrap();
+        let mut nested = subagent_run("code-writer", "a2", "toolu_a1", 700);
+        nested.parent_agent_id = Some("a1".to_string());
+        nested.spawn_depth = 2;
+        store
+            .ingest_subagent_runs(
+                &s1.id,
+                &s1.source_path,
+                &[subagent_run("Explore", "a1", "toolu_a1", 400), nested],
+            )
+            .unwrap();
+
+        let (out_tokens, sub_tokens, sub_agents) = store
+            .query(
+                "SELECT out_tokens, sub_tokens, sub_agent_count FROM events \
+                 WHERE kind = 'agent_spawn'",
+            )
+            .map(|(_, rows)| (rows[0][0].clone(), rows[0][1].clone(), rows[0][2].clone()))
+            .unwrap();
+
+        // The spawn's own run wrote 400; the run it spawned in turn wrote 700.
+        assert_eq!((out_tokens.as_str(), sub_tokens.as_str()), ("400", "700"));
+        assert_eq!(sub_agents, "1");
+    }
+
+    #[test]
+    fn a_spawn_whose_run_is_missing_keeps_its_zeros() {
+        let mut store = Store::in_memory().unwrap();
+        let s1 = session("s1");
+        store
+            .ingest_session(&s1, &[], &[agent_spawn("Explore", "toolu_gone")])
+            .unwrap();
+        store
+            .ingest_subagent_runs(
+                &s1.id,
+                &s1.source_path,
+                &[subagent_run("Explore", "a1", "toolu_a1", 400)],
+            )
+            .unwrap();
+
+        let (_, rows) = store
+            .query("SELECT out_tokens, sub_tokens FROM events WHERE target = 'toolu_gone'")
+            .unwrap();
+        assert_eq!(rows, vec![vec!["0".to_string(), "0".to_string()]]);
+    }
+
+    #[test]
+    fn a_spawn_takes_only_its_own_sessions_run() {
+        // Call ids are unique within a session, not across the store — a resumed
+        // or copied transcript can carry the same id into a second session.
+        let mut store = Store::in_memory().unwrap();
+        let (s1, s2) = (session("s1"), session("s2"));
+        store
+            .ingest_session(&s1, &[], &[agent_spawn("Explore", "toolu_a1")])
+            .unwrap();
+        store
+            .ingest_session(&s2, &[], &[agent_spawn("Explore", "toolu_a1")])
+            .unwrap();
+        store
+            .ingest_subagent_runs(
+                &s1.id,
+                &s1.source_path,
+                &[subagent_run("Explore", "a1", "toolu_a1", 400)],
+            )
+            .unwrap();
+        store
+            .ingest_subagent_runs(
+                &s2.id,
+                &s2.source_path,
+                &[subagent_run("Explore", "a1", "toolu_a1", 900)],
+            )
+            .unwrap();
+
+        let (_, rows) = store
+            .query(
+                "SELECT session_id, out_tokens FROM events \
+                 WHERE kind = 'agent_spawn' ORDER BY session_id",
+            )
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["s1".to_string(), "400".to_string()],
+                vec!["s2".to_string(), "900".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn re_ingesting_a_session_replaces_its_subagent_runs() {
+        let mut store = Store::in_memory().unwrap();
+        let s1 = session("s1");
+        store.ingest_session(&s1, &[], &[]).unwrap();
+        let runs = [subagent_run("Explore", "a1", "toolu_a1", 400)];
+        store
+            .ingest_subagent_runs(&s1.id, &s1.source_path, &runs)
+            .unwrap();
+        store
+            .ingest_subagent_runs(&s1.id, &s1.source_path, &runs)
+            .unwrap();
+
+        assert_eq!(
+            store.subagent_by_agent().unwrap(),
+            vec![AgentCost {
+                agent: Some("Explore".to_string()),
+                runs: 1,
+                out_tokens: 400,
+            }]
+        );
     }
 
     #[test]
@@ -1643,6 +1953,46 @@ mod tests {
         assert_eq!(store.meta("analyzed_at").unwrap(), None);
     }
 
+    #[test]
+    fn a_store_without_subagent_runs_gains_the_table_and_is_re_extracted() {
+        // An existing store holds the events but not the runs, and its
+        // transcripts have stopped changing — so nothing would ever populate the
+        // new table, silently, since every query still succeeds and returns
+        // nothing. Two mechanisms cover it, and neither alone would: `migrate`
+        // supplies the table, and the analyzer version is what gets the rows
+        // extracted into it.
+        let mut store = Store::in_memory().unwrap();
+        store
+            .record_ingested_file("/tmp/example/s1.jsonl", 1, 2)
+            .unwrap();
+        store
+            .conn
+            .execute_batch("DROP TABLE subagent_runs")
+            .unwrap();
+        // Stamped by a build that predates subagent extraction.
+        store.set_meta(ANALYZER_META_KEY, "1").unwrap();
+
+        let store = Store::from_connection(store.conn).unwrap();
+
+        assert!(table_exists(&store.conn, "subagent_runs").unwrap());
+        assert!(!store.is_analyzer_current().unwrap());
+    }
+
+    #[test]
+    fn reopening_a_current_store_keeps_its_fingerprints() {
+        // Migration reconciles shape only. Re-running analyze against a store
+        // the current analyzer already wrote must stay cheap.
+        let mut store = Store::in_memory().unwrap();
+        store
+            .record_ingested_file("/tmp/example/s1.jsonl", 1, 2)
+            .unwrap();
+        store.record_analyzer_version().unwrap();
+        let store = Store::from_connection(store.conn).unwrap();
+
+        assert!(store.is_analyzer_current().unwrap());
+        assert!(store.is_ingested("/tmp/example/s1.jsonl", 1, 2).unwrap());
+    }
+
     fn span_at_ctx(skill: &str, ctx_start: u64) -> Span {
         Span {
             skill: skill.to_string(),
@@ -1655,7 +2005,7 @@ mod tests {
             ctx_peak: ctx_start,
             model: None,
             is_trailing: false,
-            agent_prompt_ids: Vec::new(),
+            spawns: Vec::new(),
             sub_tokens: 0,
             sub_agent_count: 0,
             sub_tokens_estimated: false,


### PR DESCRIPTION
## Summary

- Read the `agent-<agentId>.meta.json` sidecar beside each subagent transcript, which names the agent type and the `Agent` tool call that spawned the run — the agent type appears nowhere in the transcript itself.
- Persist one `subagent_runs` row per subagent execution (agent type, own output tokens, model, spawn depth, and the ids linking it back), so the subagent bill can be split per agent type.
- Replace the `promptId` equal-split attribution heuristic with an exact join on the spawning call id, resolving nested runs through their spawn tree's root (`core::subagent::link_runs`).
- Fill each `agent_spawn` event's cost from the run it started, joined by call id and scoped to the session.
- Report the split in `usage` (table / markdown / JSON), in `doctor`'s COST section, and in the `optimize` briefing, including its schema crib.
- Update the owning specs (`events.md`, `storage.md`, `session-format.md`, `cli.md`) and the README.

## Why

Closes #9.

cclens could already answer "how many tokens did subagents burn?" and "how many times was each agent type spawned?", but not "which agent types burned those tokens?" — so the largest figure in the report was the one nothing could be done about. Spawn counts alone cannot separate an expensive agent from a cheap one that runs often, which blocks exactly the questions the aggregate invites: is one agent responsible for most of the output, is a custom agent expensive but rarely useful, do two overlapping agents both earn their keep.

The linkage turned out to be cheaper than the issue anticipated. Every subagent transcript has a sidecar carrying `agentType` and `toolUseId`, and that `toolUseId` matches the spawning `Agent` block's id exactly (167/167 depth-1 runs in a real tree). This makes the join exact rather than approximate, which also improves attribution that already existed: on a real store, the number of skill spans carrying an *estimated* subagent figure went from non-zero to **zero**, because the equal-split path now runs only for transcripts with no sidecar at all.

It also closed a blind spot. About **46%** of subagent runs are nested (an agent spawning an agent, `spawnDepth` 2–3), and those have no `Agent` `tool_use` anywhere in the main transcript — so they were invisible to the spawn-count view while their tokens sat in the session total. One agent type turned out to have run **seven times** more often than the main transcript alone suggested. Nested runs are counted at their own cost under their own type (folding them into the parent would bill an agent that only delegated) and are attributed to the main-thread work that started their tree.

Runs are a separate table rather than more `events` rows: a run happened on another thread and its cost was measured there, and giving it an `agent` surface row would double-count every spawn in the catalog×usage join. The main thread keeps its spawn event, the run keeps the cost, and `events.target` joins them.

A store written before this change has the events but not the runs, and its transcripts no longer change — so the incremental skip would keep the new table empty forever. Opening such a store clears its ingest fingerprints once, which is the whole invalidation mechanism needed.

## Review notes

Reviewed over four rounds (`/code-review`); 13 findings triaged, 11 fixed, 2 rejected with reasons. The most consequential: the briefing's schema crib originally told the AI to join `events.target = subagent_runs.tool_use_id`, which silently returns only depth-1 runs — 186 of 334 on a real store, dropping every nested run. It now names `root_tool_use_id`.

## Test Plan

- [x] `just check` (`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`) passes
- [x] `just test` passes — 157 tests, including new coverage for spawn-tree root resolution (nested, missing parent, cycle), the three-way attribution precision selection, cross-session call-id collisions, re-ingest idempotency, and the one-time store invalidation
- [x] On a real `~/.claude/projects` tree: `SUM(subagent_runs.out_tokens)` equals `SUM(sessions.sub_tokens)` equals the `agent_spawn` events' own+nested total; zero runs left unrooted; zero spans left flagged estimated
- [x] Verified the store self-heals: dropping `subagent_runs` from an existing db causes the next `analyze` to re-ingest every transcript and refill it
- [ ] Reviewer sanity check: `cclens usage` and `cclens doctor` on your own store show a per-agent split whose rows sum to the subagent total printed above them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-agent subagent usage breakdowns, including run counts and output tokens.
  * Updated `doctor` and `usage` views to show agent details, sorted by costliest output.
  * Added JSON reporting for agent-level usage data.
  * Included nested subagent runs and unknown agent types in totals.
* **Bug Fixes**
  * Improved cost attribution for nested and parallel subagent activity.
  * Added warnings when older data cannot provide a complete agent breakdown.
* **Documentation**
  * Documented subagent reporting, attribution, storage, and session metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->