### PR TITLE
fix(optimize): tell a startup saving apart from an invocation cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ derived store.
 ## What it covers
 
 - **Every configuration surface** — skills, rules, agents, MCP servers,
-  `CLAUDE.md` — catalogued with its static token cost and load mode, joined
+  `CLAUDE.md` — catalogued with its startup and on-demand token costs and load
+  mode, joined
   against actual usage to flag unused (delete), always-on heavy (slim), and
   costly+rare (trim).
 - **Where the work stumbles** — recurring tool failures by category and

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -71,7 +71,7 @@ ranking.
 | View | Answers |
 | --- | --- |
 | `doctor` | The entry point: a one-screen health check **written for someone who has never seen cclens's vocabulary** — every item says what happened, why it costs, and what to do. Sections: `WHAT TO FIX FIRST` (recurring problems as a prioritized to-do list, each routed to the owning config layer with the follow-up command), `COST` (the session-start context and output totals in plain words, humanized units), `CONFIG WORTH PRUNING` (dead or heavy config per owner), `LOOKS HEALTHY` (what explicitly needs no action). `--scope` narrows to one layer; the text form leads with actions, never a stats dump. |
-| `inventory` | The catalog×usage join per surface **row** (scope and owning project shown; usage attributed under per-project shadowing — `surfaces.md`): static cost, load mode, usage. `--scope` filters to one layer; orphaned usage (no scope to filter on) appears in the unfiltered view only. |
+| `inventory` | The catalog×usage join per surface **row** (scope and owning project shown; usage attributed under per-project shadowing — `surfaces.md`): startup cost, static cost, load mode, usage. `--scope` filters to one layer; orphaned usage (no scope to filter on) appears in the unfiltered view only. |
 | `usage` | Skill event rollups: per skill, or per time bucket (`--by`) — frequency, tokens, `ctx_growth`, duration. Leads with a token-destination line (main-thread skill output vs subagent total) so the reader sees where tokens actually go before the table. |
 | `waste` | Just the flagged opportunities (unused, costly+rare, always-on heavy, …) with their evidence and owning scope; `--scope` filters to one layer. |
 | `overhead` | Reconcile the empirical always-on floor (the leanest observed **session start**, not the context a skill happened to run at — `surfaces.md`) against the readable always-on config; the residual is the system prompt + built-in tools + MCP schemas the catalog cannot weigh. The per-project table carries the session count behind each floor, because the floor is a minimum over observations and a project with few sessions may never have caught a fresh one. Reports the metric as unavailable when no session start was observed at all. |
@@ -134,6 +134,10 @@ caveats in `events.md` / `surfaces.md`):
   lower bound.
 - Surfaces with unknown `static_tokens` (e.g. `mcp_tool` without an available
   schema) are marked unknown, never reported as zero cost.
+- A surface's startup cost and its on-demand body cost are shown as two figures,
+  never one (`surfaces.md`): a skill's body is what invoking it costs, so
+  printing it alone under a "what to trim" heading reads as a startup saving the
+  deletion never delivers.
 - "Unused" always carries the window it was evaluated over, so it is not mistaken
   for "never installed".
 
@@ -199,7 +203,7 @@ plan, gate only on applying it" shape is the design; if it changes, update
 
 Crucially the briefing is the **complete** analysis, not a headline — every
 project's friction breakdown, the full Bash/hotspot/thrash detail, and the actual
-unused / always-on-heavy surface lists with token costs — **routed the same way
+unused / always-on-heavy surface lists with startup-vs-body token costs — **routed the same way
 the views are** (see "Scope"): global sections first, then one section per
 project, so the session fixes each finding in the layer that owns it. `--scope`
 restricts the briefing to one layer and prepends an explicit scope statement

--- a/docs/specs/config-format.md
+++ b/docs/specs/config-format.md
@@ -57,6 +57,18 @@ so a tokenizer that is *close* and *consistent* is sufficient. The exact
 tokenizer is a tuning choice (see open question) injected into the weighing
 function, not hard-wired.
 
+A surface is weighed **twice**, because one number cannot answer both questions
+a reader has. `static_tokens` is the whole definition — for a skill or agent,
+what its body costs *when invoked*. `startup_tokens` is the part every session
+pays for merely having it installed: the whole text for an always-on file, the
+frontmatter `description` alone for a skill or agent, nothing for a body that
+waits (a path-conditional rule), and *unknown* for an MCP server. Only the second
+is what deleting the surface reclaims, and reporting the first as if it were the
+saving is a promise the deletion cannot keep (`surfaces.md`, "Ranking by what
+removal actually saves"). Only the description text is weighed for the startup
+half — the listing scaffolding Claude Code wraps it in is upstream's, not the
+config's, so counting it would be inventing a figure.
+
 **Static cost is a config-side estimate, not a measured runtime component.** The
 transcript exposes only a *total* prompt size, never a per-surface breakdown
 (`session-format.md`), so `static_tokens` is never validated, on its own, as the
@@ -90,11 +102,12 @@ distinction for optimization, because **always-on cost is the expensive kind**:
 | **on-demand** | `skill` / `agent` body, when invoked | Paid per use — this is what `events` measures at runtime. |
 | **tool-schema** | `mcp_tool`, built-in tools | The tool definition injected into the system/tool context. MCP schemas can be very large (the deferred-tool catalog). |
 
-So a surface records both its **full static cost** (whole definition) and its
-**load mode**, and the report distinguishes "always-on" tax from "per-use" cost.
-A skill whose body is huge but is invoked daily is a *body-trim* candidate; a
-`CLAUDE.md` that is huge is an *always-on* candidate; a rule that never fires is
-a *delete* candidate.
+So a surface records its **full static cost** (whole definition), its
+**startup cost** (the slice of that text the load mode actually injects at
+session start, per the table above), and its **load mode**, and the report
+distinguishes "always-on" tax from "per-use" cost. A skill whose body is huge but
+is invoked daily is a *body-trim* candidate; a `CLAUDE.md` that is huge is an
+*always-on* candidate; a rule that never fires is a *delete* candidate.
 
 ## The MCP tool-schema hard case
 
@@ -123,13 +136,16 @@ schema access this tool does not have.
 
 ## Frontmatter the adapter reads
 
-- `skill`: `name`, `description` (the startup-loaded text), `argument-hint`,
-  `allowed-tools`. Body length feeds the on-demand cost.
+- `skill`: `name`, `description` (the startup-loaded text — its weight *is*
+  `startup_tokens`), `argument-hint`, `allowed-tools`. Body length feeds the
+  on-demand cost. The description is read defensively: a plain or quoted scalar,
+  or a block scalar folded from its indented continuation lines; a skill
+  declaring none simply costs nothing at startup.
 - `rule`: `paths:` (the load condition) and, when present, `description:`.
   Presence of `paths:` sets the load mode to path-conditional; its absence means
   the rule is always loaded. `description:` is frequently absent on real rules —
   read it defensively, do not rely on it.
-- `agent`: `name`, `description`, `tools`, `model`.
+- `agent`: `name`, `description` (weighed like a skill's), `tools`, `model`.
 
 Parsing is defensive: unknown frontmatter keys are ignored, missing optional
 keys tolerated. A surface the adapter cannot fully parse is still catalogued

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -28,7 +28,8 @@ CREATE TABLE surfaces (
     scope         TEXT NOT NULL,    -- global | project
     project       TEXT NOT NULL,    -- owning project's normalized slug; '' for global rows
     config_path   TEXT,
-    static_tokens INTEGER,          -- token weight of the injected definition; NULL if unknown (e.g. mcp_tool)
+    static_tokens INTEGER,          -- token weight of the whole definition (a skill's body = its invocation cost); NULL if unknown (e.g. mcp_tool)
+    startup_tokens INTEGER,         -- weight of the slice loaded into every session (description for a skill/agent); NULL if unknown
     load_mode     TEXT NOT NULL,    -- startup_full | startup_description | path_conditional | on_demand | tool_schema
     attrs_json    TEXT,             -- kind-specific extras (paths glob, hook matcher, …)
     PRIMARY KEY (kind, id, scope, project)

--- a/docs/specs/surfaces.md
+++ b/docs/specs/surfaces.md
@@ -12,10 +12,13 @@ runtime cost* (events, from `events.md`) to expose optimization wedges.
 The adapter reads config into one `surface` per configurable thing, each with:
 
 - a stable `(kind, id)` identity — the join key events also carry;
-- a **static cost**: the token weight of the text it injects, plus its **load
-  mode** (startup-full / startup-description / path-conditional / on-demand /
-  tool-schema — see `config-format.md`). Load mode is what separates always-on
-  tax from per-use cost;
+- two **costs**, because one figure cannot answer both questions: a **static
+  cost** (the whole definition — for a skill or agent, what invoking it costs)
+  and a **startup cost** (the slice loaded into every session, which is all that
+  removing the surface reclaims), plus its **load mode** (startup-full /
+  startup-description / path-conditional / on-demand / tool-schema — see
+  `config-format.md`). Load mode is what separates always-on tax from per-use
+  cost, and which slice of the text each cost covers;
 - its scope (global vs project) and `config_path`.
 
 The catalog is the denominator of every optimization question: you cannot call a
@@ -91,8 +94,10 @@ A wedge is only useful if it says how much *removing the surface saves at
 session start* — and that is not its static token count. Skills and agents load
 only their **description** at startup (their body is on-demand), so deleting an
 unused one is **decluttering**, not a token win, even if its body tokenizes
-large. The `waste` view therefore ranks by `startup_savings` (see
-`core::surface`):
+large. Every view that names a surface therefore ranks by `startup_savings` and
+reports the two costs **apart** — `startup_tokens` (what removal reclaims) beside
+the on-demand body (what invoking it costs), never one figure standing for both.
+The ranking (see `core::surface`):
 
 - **measured tokens** — always-on config (`startup_full`): removing it saves that
   many tokens every session. Ranked first, largest first.
@@ -102,9 +107,12 @@ large. The `waste` view therefore ranks by `startup_savings` (see
   conditional rules): ~no startup cost, so an unused one is namespace hygiene,
   not savings. Ranked last and labelled as such.
 
-This stops the view from headlining an unused skill's body size as if deleting
-it freed that context, and lifts the genuinely paid items (heavy always-on
-rules, unused MCP servers) to the top.
+This stops a view from headlining an unused skill's body size as if deleting it
+freed that context, and lifts the genuinely paid items (heavy always-on rules,
+unused MCP servers) to the top. The rule binds the `optimize` briefing as much as
+the tables: a briefing line reads `skill/x (~7 tok at startup / 1015 tok when
+invoked)`, because the seeded session acts on those figures and a single
+unlabelled number there becomes a fix proposal that frees nothing.
 
 The "Requires" column makes the coverage explicit: **Unused** and **Costly +
 rare** apply only to usage-measurable kinds — never to `rule` / `hook` /
@@ -131,9 +139,14 @@ always-on wedge is confirmed empirically, not asserted:
 (`config-format.md`). To claim "your always-on config costs ~X every session"
 honestly, reconcile it against observed context: the **floor of the session-start
 context across sessions** is an empirical lower bound on the always-on context
-every session starts with. Comparing
-`sum(static_tokens WHERE load_mode = startup_full)` against that observed floor
-is the only evidence-backed form of the always-on claim.
+every session starts with. Comparing `sum(startup_tokens)` against that observed
+floor is the only evidence-backed form of the always-on claim. The sum spans
+every surface, not just the always-on files: a skill's description is paid at
+every session start too, so leaving descriptions out understated the config's
+share of the floor by however many skills had accumulated. Surfaces whose startup
+weight is unknown (an MCP schema) stay out of the sum rather than entering it as
+zero — they land in the unattributed residual, where the report already says the
+figure is an upper bound on system + tools + MCP.
 
 The floor must come from an actual session start (the `session_start` event —
 `events.md`), never from a skill span's `ctx_start`. Spans were the original

--- a/plugins/cclens/skills/query/SKILL.md
+++ b/plugins/cclens/skills/query/SKILL.md
@@ -50,7 +50,9 @@ sample the data before relying on an encoding:
   path), `target` the file/command when the text omits it, `project` the
   session's cwd slug.
 - `sessions` and `events` hold everything else (skill spans, tokens, models,
-  timestamps); `surfaces` is the config catalog with static token costs.
+  timestamps); `surfaces` is the config catalog, where `startup_tokens` is what a
+  surface costs every session and `static_tokens` its whole definition (a skill's
+  body, paid only when invoked).
 
 ## 3. Present
 

--- a/src/adapter/config.rs
+++ b/src/adapter/config.rs
@@ -16,8 +16,9 @@ pub fn approx_tokens(text: &str) -> u64 {
 }
 
 /// Build a `skill` surface from one `SKILL.md`. Skills load only their
-/// description at startup, so the load mode is `StartupDescription`; the static
-/// cost is the whole file (what is paid on-demand when invoked).
+/// description at startup, so the load mode is `StartupDescription`: the static
+/// cost is the whole file (what is paid on-demand when invoked) and the startup
+/// cost is the frontmatter `description` alone.
 pub fn skill_surface(id: &str, config_path: &str, content: &str, scope: &Scope) -> Surface {
     Surface {
         kind: "skill".to_string(),
@@ -25,8 +26,17 @@ pub fn skill_surface(id: &str, config_path: &str, content: &str, scope: &Scope) 
         scope: scope.clone(),
         config_path: config_path.to_string(),
         static_tokens: Some(approx_tokens(content)),
+        startup_tokens: Some(description_tokens(content)),
         load_mode: LoadMode::StartupDescription,
     }
+}
+
+/// The startup weight of a description-loaded surface: its frontmatter
+/// `description`, or zero when it declares none. Only the description text is
+/// counted — the listing scaffolding Claude Code wraps it in is not ours to
+/// weigh (`docs/specs/config-format.md`).
+fn description_tokens(content: &str) -> u64 {
+    frontmatter_description(content).map_or(0, |d| approx_tokens(&d))
 }
 
 /// Read every `<name>/SKILL.md` under a skills directory into surfaces. A
@@ -55,17 +65,20 @@ pub fn read_skill_surfaces(skills_dir: &Path, scope: &Scope) -> Vec<Surface> {
 /// only when a matching file is in play (`PathConditional`); one without is
 /// always loaded (`StartupFull`). See `docs/specs/config-format.md`.
 pub fn rule_surface(id: &str, config_path: &str, content: &str, scope: &Scope) -> Surface {
-    let load_mode = if has_paths_frontmatter(content) {
-        LoadMode::PathConditional
+    let tokens = approx_tokens(content);
+    let (load_mode, startup_tokens) = if has_paths_frontmatter(content) {
+        // Nothing until a matching file is in play; then the whole body.
+        (LoadMode::PathConditional, 0)
     } else {
-        LoadMode::StartupFull
+        (LoadMode::StartupFull, tokens)
     };
     Surface {
         kind: "rule".to_string(),
         id: id.to_string(),
         scope: scope.clone(),
         config_path: config_path.to_string(),
-        static_tokens: Some(approx_tokens(content)),
+        static_tokens: Some(tokens),
+        startup_tokens: Some(startup_tokens),
         load_mode,
     }
 }
@@ -78,33 +91,121 @@ pub fn agent_surface(id: &str, config_path: &str, content: &str, scope: &Scope) 
         scope: scope.clone(),
         config_path: config_path.to_string(),
         static_tokens: Some(approx_tokens(content)),
+        startup_tokens: Some(description_tokens(content)),
         load_mode: LoadMode::StartupDescription,
     }
 }
 
-/// Build a `claude_md` surface — always-on context paid every session.
+/// Build a `claude_md` surface — always-on context paid every session, so its
+/// whole text is startup cost.
 pub fn claude_md_surface(id: &str, config_path: &str, content: &str, scope: &Scope) -> Surface {
+    let tokens = approx_tokens(content);
     Surface {
         kind: "claude_md".to_string(),
         id: id.to_string(),
         scope: scope.clone(),
         config_path: config_path.to_string(),
-        static_tokens: Some(approx_tokens(content)),
+        static_tokens: Some(tokens),
+        startup_tokens: Some(tokens),
         load_mode: LoadMode::StartupFull,
     }
 }
 
+/// The YAML frontmatter block of a markdown file, without its `---` fences.
+/// The block ends at the first line that is *only* dashes: a substring search
+/// would also stop at a line merely starting with them, dropping every key
+/// below it — and a lost `paths:` changes a rule's load mode, not just its
+/// weight.
+fn frontmatter(content: &str) -> Option<&str> {
+    let opened = content.trim_start().strip_prefix("---")?;
+    let body = &opened[opened.find('\n')? + 1..];
+    let mut end = 0;
+    for line in body.split_inclusive('\n') {
+        if line.trim() == "---" {
+            return Some(&body[..end]);
+        }
+        end += line.len();
+    }
+    None
+}
+
 /// Whether a markdown file's YAML frontmatter declares a `paths:` key.
 fn has_paths_frontmatter(content: &str) -> bool {
-    let Some(rest) = content.trim_start().strip_prefix("---") else {
-        return false;
+    frontmatter(content).is_some_and(|block| {
+        block
+            .lines()
+            .any(|line| line.trim_start().starts_with("paths:"))
+    })
+}
+
+/// The frontmatter `description` — the text a skill or agent contributes to
+/// every session's startup listing. Parsed defensively: a plain or quoted
+/// scalar, or a block scalar, in every case folded together with the indented
+/// continuation lines that follow it — YAML wraps a value onto those lines with
+/// or without a `>` / `|` indicator, and reading only the first line would
+/// understate the startup cost. A file with no frontmatter, or none declaring
+/// the key, yields `None`.
+fn frontmatter_description(content: &str) -> Option<String> {
+    let mut lines = frontmatter(content)?.lines();
+    let first = loop {
+        // Only a top-level key is the surface's own description; an indented
+        // `description:` belongs to some nested mapping.
+        match lines.next()?.strip_prefix("description:") {
+            Some(value) => break value.trim(),
+            None => continue,
+        }
     };
-    let Some(end) = rest.find("\n---") else {
-        return false;
-    };
-    rest[..end]
-        .lines()
-        .any(|line| line.trim_start().starts_with("paths:"))
+    // A block indicator is syntax, not text; anything else on the line is the
+    // value's first fragment. Inside a block scalar (or quotes) a `#` is literal
+    // text, so comments are only stripped from a plain scalar.
+    let block = first.starts_with('>') || first.starts_with('|');
+    let mut folded: Vec<&str> = Vec::new();
+    if !(first.is_empty() || block) {
+        folded.push(strip_comment(first, block));
+    }
+    folded.extend(
+        lines
+            .take_while(|line| line.trim().is_empty() || line.starts_with([' ', '\t']))
+            .map(|line| strip_comment(line.trim(), block))
+            .filter(|line| !line.is_empty()),
+    );
+    if folded.is_empty() {
+        return None;
+    }
+    // Unquote the folded value, not a fragment of it: a quoted scalar's closing
+    // quote may sit on the last continuation line.
+    let value = folded.join(" ");
+    Some(unquote(&value).to_string())
+}
+
+/// Drop a plain scalar's trailing YAML comment — a `#` that opens the value or
+/// follows whitespace is comment syntax, and no session ever loads it. Inside a
+/// block scalar (`block`) or quotes, a `#` is literal text and stays.
+fn strip_comment(value: &str, block: bool) -> &str {
+    if block || value.starts_with(['"', '\'']) {
+        return value;
+    }
+    if value.starts_with('#') {
+        return "";
+    }
+    // Any whitespace opens a comment, not only a space.
+    value
+        .char_indices()
+        .find(|&(at, ch)| ch == '#' && value[..at].ends_with(char::is_whitespace))
+        .map_or(value, |(at, _)| value[..at].trim_end())
+}
+
+/// Strip one layer of matching surrounding quotes, if present.
+fn unquote(value: &str) -> &str {
+    for quote in ['"', '\''] {
+        if let Some(inner) = value
+            .strip_prefix(quote)
+            .and_then(|v| v.strip_suffix(quote))
+        {
+            return inner;
+        }
+    }
+    value
 }
 
 /// Read every `<name>.md` agent file in a directory into surfaces.
@@ -218,6 +319,9 @@ pub fn read_mcp_server_surfaces(mcp_json: &Path, scope: &Scope) -> Vec<Surface> 
             scope: scope.clone(),
             config_path: mcp_json.display().to_string(),
             static_tokens: None,
+            // Its schema is loaded every session, but the weight is unknowable
+            // from local config — unknown, never a false zero.
+            startup_tokens: None,
             load_mode: LoadMode::ToolSchema,
         })
         .collect()
@@ -283,6 +387,153 @@ mod tests {
         assert_eq!(surface.scope, Scope::Global);
         assert_eq!(surface.static_tokens, Some(2));
         assert_eq!(surface.load_mode, LoadMode::StartupDescription);
+    }
+
+    #[test]
+    fn a_skill_pays_only_its_description_at_startup() {
+        // The body is loaded on invocation, so the startup cost is the
+        // description alone — 25 chars, ~7 tokens — not the 1000-char file.
+        let content = format!(
+            "---\nname: repro\ndescription: short startup description\n---\n{}",
+            "x".repeat(1000)
+        );
+        let surface = skill_surface(
+            "repro",
+            "/tmp/skills/repro/SKILL.md",
+            &content,
+            &Scope::Global,
+        );
+
+        assert_eq!(surface.startup_tokens, Some(7));
+        assert_eq!(surface.static_tokens, Some(approx_tokens(&content)));
+    }
+
+    #[test]
+    fn a_description_less_skill_costs_nothing_at_startup() {
+        let surface = skill_surface(
+            "bare",
+            "/tmp/skills/bare/SKILL.md",
+            "# body",
+            &Scope::Global,
+        );
+        assert_eq!(surface.startup_tokens, Some(0));
+    }
+
+    #[test]
+    fn a_quoted_or_folded_description_is_read_like_any_other() {
+        let quoted = "---\ndescription: \"abcdefgh\"\n---\nbody";
+        assert_eq!(frontmatter_description(quoted).as_deref(), Some("abcdefgh"));
+        // A folded block scalar spreads the description over the indented lines
+        // that follow; all of it is startup-loaded text.
+        let folded = "---\ndescription: >-\n  abcd\n  efgh\n---\nbody";
+        assert_eq!(
+            frontmatter_description(folded).as_deref(),
+            Some("abcd efgh")
+        );
+        // No frontmatter at all, and a frontmatter without the key.
+        assert_eq!(frontmatter_description("# body"), None);
+        assert_eq!(frontmatter_description("---\nname: x\n---\nbody"), None);
+    }
+
+    #[test]
+    fn a_wrapped_description_keeps_its_continuation_lines() {
+        // A plain scalar needs no `>` to wrap: YAML folds the indented lines
+        // that follow into one value, and all of it is startup-loaded text.
+        // Reading only the first line would understate the startup cost.
+        let wrapped = "---\ndescription: abcd\n  efgh\n---\nbody";
+        assert_eq!(
+            frontmatter_description(wrapped).as_deref(),
+            Some("abcd efgh")
+        );
+        // A quoted value may span lines too — the quotes belong to the folded
+        // value, not to its first fragment.
+        let quoted = "---\ndescription: \"abcd\n  efgh\"\n---\nbody";
+        assert_eq!(
+            frontmatter_description(quoted).as_deref(),
+            Some("abcd efgh")
+        );
+    }
+
+    #[test]
+    fn only_a_line_that_is_just_dashes_closes_the_frontmatter() {
+        // A value line merely starting with dashes must not end the block:
+        // truncating there drops the keys below it, and for a rule that means
+        // losing `paths:` — which flips its load mode, not just its weight.
+        let content = "---\nname: x\n---nope\ndescription: abcd\n---\nbody";
+        assert_eq!(frontmatter_description(content).as_deref(), Some("abcd"));
+        let ruled = "---\n---nope\npaths:\n  - \"src/**\"\n---\nbody";
+        assert_eq!(
+            rule_surface("r", "/c/r.md", ruled, &Scope::Global).load_mode,
+            LoadMode::PathConditional
+        );
+        // CRLF frontmatter reads the same.
+        let crlf = "---\r\ndescription: abcd\r\n---\r\nbody";
+        assert_eq!(frontmatter_description(crlf).as_deref(), Some("abcd"));
+    }
+
+    #[test]
+    fn an_inline_comment_is_not_part_of_the_description() {
+        // Claude Code loads what YAML says the value is, and YAML drops a
+        // whitespace-preceded `#` — counting it would weigh text no session
+        // ever sees.
+        let commented = "---\ndescription: Real text # not the description\n---\nbody";
+        assert_eq!(
+            frontmatter_description(commented).as_deref(),
+            Some("Real text")
+        );
+        // Any whitespace opens a comment, not only a space.
+        let tabbed = "---\ndescription: Real text\t# not the description\n---\nbody";
+        assert_eq!(
+            frontmatter_description(tabbed).as_deref(),
+            Some("Real text")
+        );
+        // Inside quotes, and inside a block scalar, a `#` is literal text.
+        let quoted = "---\ndescription: \"a # b\"\n---\nbody";
+        assert_eq!(frontmatter_description(quoted).as_deref(), Some("a # b"));
+        let block = "---\ndescription: |\n  a # b\n---\nbody";
+        assert_eq!(frontmatter_description(block).as_deref(), Some("a # b"));
+    }
+
+    #[test]
+    fn an_agent_pays_only_its_description_at_startup() {
+        let content = "---\ndescription: abcdefgh\n---\nlong body";
+        let surface = agent_surface("explorer", "/c/explorer.md", content, &Scope::Global);
+        assert_eq!(surface.startup_tokens, Some(2));
+        assert_eq!(surface.static_tokens, Some(approx_tokens(content)));
+    }
+
+    #[test]
+    fn an_always_on_rule_pays_its_whole_text_at_startup() {
+        let surface = rule_surface("convention", "/cfg/convention.md", "abcd", &Scope::Global);
+        assert_eq!(surface.startup_tokens, Some(1));
+        assert_eq!(surface.static_tokens, Some(1));
+    }
+
+    #[test]
+    fn a_path_conditional_rule_pays_nothing_until_it_fires() {
+        let content = "---\npaths:\n  - \"src/**/*.rs\"\n---\n# Rule body";
+        let surface = rule_surface("spec-sync", "/cfg/spec-sync.md", content, &Scope::Global);
+        assert_eq!(surface.startup_tokens, Some(0));
+        assert_eq!(surface.static_tokens, Some(approx_tokens(content)));
+    }
+
+    #[test]
+    fn claude_md_pays_its_whole_text_at_startup() {
+        let surface = claude_md_surface("global", "/c/CLAUDE.md", "abcd", &Scope::Global);
+        assert_eq!(surface.startup_tokens, Some(1));
+    }
+
+    #[test]
+    fn an_mcp_server_startup_cost_is_unknown_not_zero() {
+        let dir = std::env::temp_dir().join(format!("cclens-test-mcp-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".mcp.json");
+        fs::write(&path, r#"{"mcpServers":{"playwright":{}}}"#).unwrap();
+
+        let surfaces = read_mcp_server_surfaces(&path, &Scope::Global);
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(surfaces[0].startup_tokens, None);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,7 +23,7 @@ use crate::core::scope::{ScopeFilter, split_friction};
 use crate::core::span::{DEFAULT_IDLE_GAP_MS, SessionStart, extract_spans, session_start};
 use crate::core::surface::{
     LoadMode, Scope, StartupSavings, Surface, Wedge, classify_wedge, is_usage_measurable,
-    startup_savings,
+    on_demand_tokens, startup_savings,
 };
 use crate::core::thrash::detect_thrash;
 use crate::core::usage::{attribute_subagents, extract_usage_events, output_tokens};
@@ -633,11 +633,17 @@ struct ScopedWedges {
 }
 
 fn config_wedges(store: &Store) -> Result<ScopedWedges> {
-    let surface_ref = |e: &crate::store::CatalogEntry| optimize_mod::SurfaceRef {
-        kind: e.kind.clone(),
-        id: e.id.clone(),
-        static_tokens: e.static_tokens,
-    };
+    // Carry the cost split, not one figure: a skill's file weight is its
+    // invocation cost, and rendering it as the trim saving promised startup
+    // context that deleting it never frees (`docs/specs/surfaces.md`).
+    let surface_ref =
+        |e: &crate::store::CatalogEntry, load_mode: LoadMode| optimize_mod::SurfaceRef {
+            kind: e.kind.clone(),
+            id: e.id.clone(),
+            startup_tokens: e.startup_tokens,
+            on_demand_tokens: on_demand_tokens(load_mode, e.static_tokens.map(|t| t as u64))
+                .map(|t| t as i64),
+        };
     let mut scoped = ScopedWedges {
         global: WedgeRefs::default(),
         projects: std::collections::HashMap::new(),
@@ -651,10 +657,10 @@ fn config_wedges(store: &Store) -> Result<ScopedWedges> {
         let load_mode = LoadMode::from_label(&entry.load_mode).unwrap_or(LoadMode::OnDemand);
         let static_tokens = entry.static_tokens.map(|t| t as u64);
         if is_usage_measurable(&entry.kind) && entry.uses == 0 {
-            refs.unused.push(surface_ref(&entry));
+            refs.unused.push(surface_ref(&entry, load_mode));
         }
         if load_mode.is_always_on() && static_tokens.is_some_and(|t| t >= HEAVY_TOKENS) {
-            refs.always_on_heavy.push(surface_ref(&entry));
+            refs.always_on_heavy.push(surface_ref(&entry, load_mode));
         }
     }
     Ok(scoped)
@@ -997,7 +1003,10 @@ fn prune_phrase(
         ));
     }
     if !always_on_heavy.is_empty() {
-        let tokens: i64 = always_on_heavy.iter().filter_map(|s| s.static_tokens).sum();
+        let tokens: i64 = always_on_heavy
+            .iter()
+            .filter_map(|s| s.startup_tokens)
+            .sum();
         parts.push(format!(
             "{} loaded every session (~{} tokens each time)",
             plural(always_on_heavy.len(), "heavy file"),
@@ -1428,8 +1437,12 @@ fn overhead(format: Format, frozen: bool, db: &Path) -> Result<()> {
         "Observed always-on floor (leanest session-start context): {}",
         style.bold(&format!("{floor} tokens"))
     );
-    println!("  readable config (CLAUDE.md + always-on rules):          {config} tokens");
-    println!("  residual (system prompt + built-in tools + MCP schemas): {residual} tokens");
+    println!(
+        "  readable config (CLAUDE.md, always-on rules, skill/agent descriptions): {config} tokens"
+    );
+    println!(
+        "  residual (system prompt + built-in tools + MCP schemas):                {residual} tokens"
+    );
     println!(
         "{}",
         style.dim(
@@ -1920,6 +1933,7 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
                     "scope": entry.scope,
                     "project": if entry.project.is_empty() { None } else { Some(&entry.project) },
                     "static_tokens": entry.static_tokens,
+                    "startup_tokens": entry.startup_tokens,
                     "uses": if measurable { Some(entry.uses) } else { None },
                     "load_mode": entry.load_mode,
                     "status": if measurable && entry.uses == 0 { "unused" }
@@ -1932,7 +1946,8 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
                 if !catalogued.contains(&(kind.as_str(), id.as_str())) {
                     items.push(serde_json::json!({
                         "kind": kind, "id": id, "scope": null, "project": null,
-                        "static_tokens": null, "uses": count, "load_mode": null,
+                        "static_tokens": null, "startup_tokens": null,
+                        "uses": count, "load_mode": null,
                         "status": "orphaned",
                     }));
                 }
@@ -1948,9 +1963,11 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
     preamble(
         format,
         "Everything installed in your config — skills, rules, agents, MCP servers,\n\
-         CLAUDE.md — with its static token weight, where it is installed (scope), and\n\
-         whether it was ever used. UNUSED marks delete candidates; rules and CLAUDE.md\n\
-         are catalog-only because using them leaves no trace in transcripts.",
+         CLAUDE.md — with where it is installed (scope) and whether it was ever used.\n\
+         \"start tok\" is what every session pays for having it installed; \"static tok\"\n\
+         is the whole definition, which for a skill or agent is paid only on invocation.\n\
+         UNUSED marks delete candidates; rules and CLAUDE.md are catalog-only because\n\
+         using them leaves no trace in transcripts.",
     );
     let mut rows: Vec<Vec<String>> = Vec::new();
     for entry in &catalog {
@@ -1965,14 +1982,13 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
         } else {
             ("-".to_string(), "(catalog-only)")
         };
-        let static_tokens = entry
-            .static_tokens
-            .map_or_else(|| "?".to_string(), |tokens| tokens.to_string());
+        let tokens = |value: Option<i64>| value.map_or_else(|| "?".to_string(), |t| t.to_string());
         rows.push(vec![
             entry.kind.clone(),
             entry.id.clone(),
             scope_cell(&entry.scope, &entry.project),
-            static_tokens,
+            tokens(entry.startup_tokens),
+            tokens(entry.static_tokens),
             uses_cell,
             entry.load_mode.clone(),
             status.to_string(),
@@ -1994,6 +2010,7 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
                 id.clone(),
                 "-".to_string(),
                 "-".to_string(),
+                "-".to_string(),
                 count.to_string(),
                 "-".to_string(),
                 "ORPHANED".to_string(),
@@ -2006,6 +2023,7 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
             "kind",
             "id",
             "scope",
+            "start tok",
             "static tok",
             "uses",
             "load mode",
@@ -2015,6 +2033,7 @@ fn inventory(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> R
             Align::Left,
             Align::Left,
             Align::Left,
+            Align::Right,
             Align::Right,
             Align::Right,
             Align::Left,
@@ -2064,6 +2083,10 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
         project: &'a str,
         uses: i64,
         savings: StartupSavings,
+        /// What every session pays for having it installed.
+        startup_tokens: Option<u64>,
+        /// What its body costs when loaded — an invocation cost, never a saving.
+        on_demand_tokens: Option<u64>,
     }
 
     let mut found: Vec<Row> = Vec::new();
@@ -2071,6 +2094,7 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
         let measurable = is_usage_measurable(&entry.kind);
         let load_mode = LoadMode::from_label(&entry.load_mode).unwrap_or(LoadMode::OnDemand);
         let static_tokens = entry.static_tokens.map(|tokens| tokens as u64);
+        let startup_tokens = entry.startup_tokens.map(|tokens| tokens as u64);
         if let Some(wedge) = classify_wedge(
             measurable,
             load_mode,
@@ -2085,7 +2109,9 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
                 scope: &entry.scope,
                 project: &entry.project,
                 uses: entry.uses,
-                savings: startup_savings(load_mode, static_tokens),
+                savings: startup_savings(load_mode, startup_tokens),
+                startup_tokens,
+                on_demand_tokens: on_demand_tokens(load_mode, static_tokens),
             });
         }
     }
@@ -2111,8 +2137,10 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
                     "project": if row.project.is_empty() { None } else { Some(row.project) },
                     "savings": savings,
                     "savings_tokens": savings_tokens,
+                    "startup_tokens": row.startup_tokens,
+                    "on_demand_tokens": row.on_demand_tokens,
                     "uses": if is_usage_measurable(row.kind) { Some(row.uses) } else { None },
-                    "suggestion": savings_suggestion(row.wedge, row.savings),
+                    "suggestion": savings_suggestion(row.wedge, row.savings, row.on_demand_tokens),
                 })
             })
             .collect();
@@ -2126,8 +2154,8 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
     preamble(
         format,
         "Concrete cleanup opportunities in your config, ranked by what removing each\n\
-         one actually saves at session start. \"~0\" means deleting only declutters —\n\
-         the body loads on demand, so it costs nothing until used.",
+         one actually saves at session start. A \"~\" figure is declutter-only — just\n\
+         the description is loaded at startup; the body costs nothing until invoked.",
     );
     let rows: Vec<Vec<String>> = found
         .iter()
@@ -2141,9 +2169,9 @@ fn waste(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resul
                 row.wedge.label().to_string(),
                 format!("{}/{}", row.kind, row.id),
                 scope_cell(row.scope, row.project),
-                savings_cell(row.savings),
+                savings_cell(row.savings, row.startup_tokens),
                 uses_cell,
-                savings_suggestion(row.wedge, row.savings),
+                savings_suggestion(row.wedge, row.savings, row.on_demand_tokens),
             ]
         })
         .collect();
@@ -2180,24 +2208,31 @@ fn savings_rank(savings: StartupSavings) -> (u8, std::cmp::Reverse<u64>) {
     }
 }
 
-fn savings_cell(savings: StartupSavings) -> String {
+fn savings_cell(savings: StartupSavings, startup_tokens: Option<u64>) -> String {
     match savings {
         StartupSavings::Tokens(n) => format!("{n}/sess"),
         StartupSavings::UnknownSchema => "schema?".to_string(),
-        StartupSavings::Declutter => "~0".to_string(),
+        // Negligible, but measured: a description-loaded surface still costs its
+        // description every session, and that is all removing it reclaims.
+        StartupSavings::Declutter => format!("~{}/sess", startup_tokens.unwrap_or(0)),
     }
 }
 
-/// A suggestion honest about whether removal saves context or only declutters.
-fn savings_suggestion(wedge: Wedge, savings: StartupSavings) -> String {
+/// A suggestion honest about whether removal saves context or only declutters —
+/// naming the body cost as an invocation cost so it is not read as a saving.
+fn savings_suggestion(wedge: Wedge, savings: StartupSavings, on_demand: Option<u64>) -> String {
+    let body = match on_demand {
+        Some(n) => format!("body is {n} tok when invoked"),
+        None => "body is on-demand".to_string(),
+    };
     match savings {
         StartupSavings::Tokens(n) => format!("removing saves ~{n} tokens every session"),
         StartupSavings::UnknownSchema => {
             "disable: drops its tool schema from every session (real, unmeasured)".to_string()
         }
         StartupSavings::Declutter => match wedge {
-            Wedge::Unused => "declutter only: body is on-demand, ~no startup saving".to_string(),
-            _ => "heavy only when invoked; rarely used".to_string(),
+            Wedge::Unused => format!("declutter only: {body}, ~no startup saving"),
+            _ => format!("heavy only when invoked ({body}); rarely used"),
         },
     }
 }
@@ -2610,5 +2645,26 @@ mod tests {
             normalize_root("/tmp/example/repo/.wt"),
             "/tmp/example/repo/.wt"
         );
+    }
+
+    #[test]
+    fn a_declutter_row_shows_the_description_it_would_reclaim() {
+        // The measured startup cost, not the body — deleting an unused skill
+        // frees its description, and that is what the column promises.
+        assert_eq!(
+            savings_cell(StartupSavings::Declutter, Some(7)),
+            "~7/sess".to_string()
+        );
+        assert_eq!(
+            savings_cell(StartupSavings::Tokens(922), Some(922)),
+            "922/sess".to_string()
+        );
+    }
+
+    #[test]
+    fn an_unused_body_is_suggested_as_an_invocation_cost_not_a_saving() {
+        let suggestion = savings_suggestion(Wedge::Unused, StartupSavings::Declutter, Some(1015));
+        assert!(suggestion.contains("1015 tok when invoked"));
+        assert!(suggestion.contains("declutter only"));
     }
 }

--- a/src/core/optimize.rs
+++ b/src/core/optimize.rs
@@ -78,12 +78,21 @@ pub struct FrictionCat {
     pub examples: Vec<String>,
 }
 
-/// A configuration surface referenced in the config sections.
+/// A configuration surface referenced in the config sections. The two costs are
+/// kept apart because they answer different questions: `startup_tokens` is what
+/// removing the surface actually reclaims from every session, `on_demand_tokens`
+/// is what its body costs when it is invoked. Collapsing them into one figure
+/// made an unused skill's body read as a startup saving (`docs/specs/surfaces.md`).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SurfaceRef {
     pub kind: String,
     pub id: String,
-    pub static_tokens: Option<i64>,
+    /// Tokens added to every session's startup context; `None` when unknown
+    /// (an MCP server's tool schema, weighable only at runtime).
+    pub startup_tokens: Option<i64>,
+    /// Tokens paid when the body is loaded; `None` for a surface with no body
+    /// beyond what startup already pays.
+    pub on_demand_tokens: Option<i64>,
 }
 
 /// A thrash burst — a file re-edited many times in a short window.
@@ -317,7 +326,10 @@ fn render_config_to_trim(
     out.push_str(&format!("\n## {heading}\n"));
     if !unused.is_empty() {
         out.push_str(&format!(
-            "\n### Unused surfaces ({}) — installed but never used in the window\n",
+            "\n### Unused surfaces ({}) — installed but never used in the window\n\
+             Each line gives what the surface costs at every session start — the only part \
+             removing it reclaims — and, where it has a body, what that body costs when \
+             invoked, which an unused surface has never paid.\n",
             unused.len()
         ));
         for s in unused {
@@ -335,11 +347,18 @@ fn render_config_to_trim(
     }
 }
 
+/// Render one surface with its cost split, so a body figure can never be read as
+/// a startup saving.
 fn render_surface(s: &SurfaceRef) -> String {
-    match s.static_tokens {
-        Some(t) => format!("{}/{} ({} tok)", s.kind, s.id, t),
-        None => format!("{}/{} (unknown tok)", s.kind, s.id),
-    }
+    let cost = match (s.startup_tokens, s.on_demand_tokens) {
+        (Some(startup), Some(body)) => {
+            format!("~{startup} tok at startup / {body} tok when invoked")
+        }
+        (Some(startup), None) => format!("{startup} tok every session"),
+        (None, Some(body)) => format!("{body} tok when invoked; startup cost unknown"),
+        (None, None) => "loaded every session, size unknown".to_string(),
+    };
+    format!("{}/{} ({cost})", s.kind, s.id)
 }
 
 /// How to reach the analyzed store for `cclens sql` — appended so the
@@ -430,15 +449,25 @@ mod tests {
             cd_pct: Some(53),
             top_commands: vec![("cd".to_string(), 200), ("cargo".to_string(), 80)],
             hotspots: vec![("lib.rs".to_string(), 40)],
-            unused: vec![SurfaceRef {
-                kind: "skill".to_string(),
-                id: "code-review".to_string(),
-                static_tokens: Some(1345),
-            }],
+            unused: vec![
+                SurfaceRef {
+                    kind: "skill".to_string(),
+                    id: "code-review".to_string(),
+                    startup_tokens: Some(9),
+                    on_demand_tokens: Some(1345),
+                },
+                SurfaceRef {
+                    kind: "mcp_server".to_string(),
+                    id: "playwright".to_string(),
+                    startup_tokens: None,
+                    on_demand_tokens: None,
+                },
+            ],
             always_on_heavy: vec![SurfaceRef {
                 kind: "rule".to_string(),
                 id: "git/safety".to_string(),
-                static_tokens: Some(922),
+                startup_tokens: Some(922),
+                on_demand_tokens: None,
             }],
             steer_pct: Some(13),
             correct_pct: Some(6),
@@ -469,7 +498,8 @@ mod tests {
                 unused: vec![SurfaceRef {
                     kind: "skill".to_string(),
                     id: "deploy".to_string(),
-                    static_tokens: Some(500),
+                    startup_tokens: Some(5),
+                    on_demand_tokens: Some(500),
                 }],
                 always_on_heavy: vec![],
             }],
@@ -487,7 +517,8 @@ mod tests {
         assert_eq!(json["projects"][0]["project"], "alpha");
         assert_eq!(json["projects"][0]["friction"][0]["count"], 92);
         assert_eq!(json["projects"][0]["thrash"][0]["edits"], 25);
-        assert_eq!(json["unused"][0]["static_tokens"], 1345);
+        assert_eq!(json["unused"][0]["startup_tokens"], 9);
+        assert_eq!(json["unused"][0]["on_demand_tokens"], 1345);
     }
 
     #[test]
@@ -585,10 +616,26 @@ mod tests {
     #[test]
     fn briefing_lists_concrete_config_surfaces_not_just_counts() {
         let brief = render_briefing(&findings(), &ScopeFilter::All);
-        assert!(brief.contains("skill/code-review (1345 tok)"));
-        assert!(brief.contains("rule/git/safety (922 tok)"));
+        // An unused skill's body is what it costs *when invoked*; deleting it
+        // reclaims only the description. Reporting the body as the trim figure
+        // would promise ~1345 tokens of startup context that removal never frees.
+        assert!(brief.contains("skill/code-review (~9 tok at startup / 1345 tok when invoked)"));
+        // An MCP server's schema is real every-session cost the catalog cannot weigh.
+        assert!(brief.contains("mcp_server/playwright (loaded every session, size unknown)"));
+        // An always-on file is paid in full at startup, so one figure says it all.
+        assert!(brief.contains("rule/git/safety (922 tok every session)"));
         // The project's own wedge sits in the project section.
-        assert!(brief.contains("skill/deploy (500 tok)"));
+        assert!(brief.contains("skill/deploy (~5 tok at startup / 500 tok when invoked)"));
+    }
+
+    #[test]
+    fn the_unused_section_says_what_removal_actually_saves() {
+        let brief = render_briefing(&findings(), &ScopeFilter::All);
+        assert!(brief.contains("the only part removing it reclaims"));
+        // The same list holds an MCP server whose schema *is* loaded every
+        // session, so the section must not claim an unused surface is free.
+        assert!(brief.contains("mcp_server/playwright (loaded every session"));
+        assert!(!brief.contains("already costs nothing"));
     }
 
     #[test]

--- a/src/core/surface.rs
+++ b/src/core/surface.rs
@@ -85,9 +85,18 @@ pub struct Surface {
     pub id: String,
     pub scope: Scope,
     pub config_path: String,
-    /// Token weight of the injected definition; `None` when it cannot be weighed
-    /// (e.g. an MCP tool schema with no available source).
+    /// Token weight of the whole injected definition; `None` when it cannot be
+    /// weighed (e.g. an MCP tool schema with no available source). For a surface
+    /// with an on-demand body this is the *invocation* cost, not the startup one
+    /// — `startup_tokens` is what a session pays for merely having it installed.
     pub static_tokens: Option<u64>,
+    /// Token weight of the part loaded into **every** session's startup context:
+    /// the whole text for always-on surfaces, only the description for skills and
+    /// agents, nothing for a body that waits to be invoked. `None` when unknown
+    /// (an MCP server's tool schema). Keeping this apart from `static_tokens` is
+    /// what stops a body cost from being read as a startup saving
+    /// (`docs/specs/surfaces.md`).
+    pub startup_tokens: Option<u64>,
     pub load_mode: LoadMode,
 }
 
@@ -155,10 +164,24 @@ pub enum StartupSavings {
     Declutter,
 }
 
-/// The startup token saving from removing a surface, by load mode.
-pub fn startup_savings(load_mode: LoadMode, static_tokens: Option<u64>) -> StartupSavings {
+/// What a surface costs when its body is actually loaded — the invocation cost
+/// of a skill or agent, the firing cost of a path-conditional rule. `None` for
+/// surfaces with no separate body: an always-on file is already paid in full at
+/// startup, and a tool schema is not a body at all. Reports pair this with
+/// `startup_tokens` so a body figure is never read as a startup saving.
+pub fn on_demand_tokens(load_mode: LoadMode, static_tokens: Option<u64>) -> Option<u64> {
     match load_mode {
-        LoadMode::StartupFull => StartupSavings::Tokens(static_tokens.unwrap_or(0)),
+        LoadMode::StartupDescription | LoadMode::PathConditional | LoadMode::OnDemand => {
+            static_tokens
+        }
+        LoadMode::StartupFull | LoadMode::ToolSchema => None,
+    }
+}
+
+/// The startup token saving from removing a surface, by load mode.
+pub fn startup_savings(load_mode: LoadMode, startup_tokens: Option<u64>) -> StartupSavings {
+    match load_mode {
+        LoadMode::StartupFull => StartupSavings::Tokens(startup_tokens.unwrap_or(0)),
         LoadMode::ToolSchema => StartupSavings::UnknownSchema,
         LoadMode::StartupDescription | LoadMode::PathConditional | LoadMode::OnDemand => {
             StartupSavings::Declutter
@@ -249,6 +272,23 @@ mod tests {
     }
 
     #[test]
+    fn on_demand_cost_exists_only_for_a_body_that_waits_to_be_loaded() {
+        // A skill's file weight is paid on invocation...
+        assert_eq!(
+            on_demand_tokens(LoadMode::StartupDescription, Some(1015)),
+            Some(1015)
+        );
+        // ...as is a path-conditional rule's, when its glob fires.
+        assert_eq!(
+            on_demand_tokens(LoadMode::PathConditional, Some(500)),
+            Some(500)
+        );
+        // An always-on file has no separate on-demand cost — it is already paid.
+        assert_eq!(on_demand_tokens(LoadMode::StartupFull, Some(900)), None);
+        assert_eq!(on_demand_tokens(LoadMode::ToolSchema, None), None);
+    }
+
+    #[test]
     fn startup_savings_reflects_what_is_actually_paid_at_startup() {
         // An always-on rule: removing it saves real tokens every session.
         assert_eq!(
@@ -260,9 +300,10 @@ mod tests {
             startup_savings(LoadMode::ToolSchema, None),
             StartupSavings::UnknownSchema
         );
-        // A skill: body is on-demand, so removal is decluttering, not a token win.
+        // A skill: only its description is startup-loaded, so removal is
+        // decluttering, not a token win — however large the body.
         assert_eq!(
-            startup_savings(LoadMode::StartupDescription, Some(2000)),
+            startup_savings(LoadMode::StartupDescription, Some(7)),
             StartupSavings::Declutter
         );
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS surfaces (
     project       TEXT NOT NULL DEFAULT '',
     config_path   TEXT,
     static_tokens INTEGER,
+    startup_tokens INTEGER,
     load_mode     TEXT NOT NULL,
     PRIMARY KEY (kind, id, scope, project)
 );
@@ -178,7 +179,12 @@ pub struct CatalogEntry {
     pub scope: String,
     /// The owning project's normalized slug; empty for global rows.
     pub project: String,
+    /// The whole definition's weight — for a skill or agent, what its body
+    /// costs when invoked, not what having it installed costs.
     pub static_tokens: Option<i64>,
+    /// What this surface adds to every session's startup context; `None` when
+    /// unknown (an MCP server's tool schema).
+    pub startup_tokens: Option<i64>,
     pub load_mode: String,
     pub uses: i64,
 }
@@ -637,14 +643,17 @@ impl Store {
         Ok(rows)
     }
 
-    /// Total tokens of **global** always-on (startup_full) config — what every
-    /// session pays unconditionally from `~/.claude` regardless of project.
-    /// Project config is always-on only for its own sessions
-    /// (`always_on_config_tokens_for`).
+    /// Total startup tokens of **global** config — what every session pays
+    /// unconditionally from `~/.claude` regardless of project: always-on files
+    /// in full, plus the descriptions skills and agents contribute to the
+    /// startup listing. Bodies that wait to be invoked weigh nothing here, and a
+    /// surface whose startup weight is unknown (an MCP schema) is left out of
+    /// the sum rather than counted as zero. Project config is always-on only for
+    /// its own sessions (`always_on_config_tokens_for`).
     pub fn always_on_config_tokens(&self) -> Result<i64> {
         let total = self.conn.query_row(
-            "SELECT COALESCE(SUM(static_tokens), 0) FROM surfaces
-             WHERE load_mode = 'startup_full' AND scope = 'global'",
+            "SELECT COALESCE(SUM(startup_tokens), 0) FROM surfaces
+             WHERE scope = 'global'",
             [],
             |row| row.get(0),
         )?;
@@ -808,8 +817,9 @@ impl Store {
         for surface in surfaces {
             tx.execute(
                 "INSERT OR REPLACE INTO surfaces
-                   (kind, id, scope, project, config_path, static_tokens, load_mode)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                   (kind, id, scope, project, config_path, static_tokens,
+                    startup_tokens, load_mode)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 (
                     &surface.kind,
                     &surface.id,
@@ -817,6 +827,7 @@ impl Store {
                     surface.scope.project(),
                     &surface.config_path,
                     surface.static_tokens,
+                    surface.startup_tokens,
                     surface.load_mode.label(),
                 ),
             )?;
@@ -832,8 +843,8 @@ impl Store {
     /// (`docs/specs/surfaces.md`).
     pub fn effective_catalog(&self) -> Result<Vec<CatalogEntry>> {
         let mut stmt = self.conn.prepare(
-            "SELECT f.kind, f.id, f.scope, f.project, f.static_tokens, f.load_mode,
-                    COUNT(u.event_id)
+            "SELECT f.kind, f.id, f.scope, f.project, f.static_tokens,
+                    f.startup_tokens, f.load_mode, COUNT(u.event_id)
              FROM surfaces f
              LEFT JOIN (SELECT e.id AS event_id, e.surface_kind, e.surface_id,
                                s.project AS session_project
@@ -855,8 +866,9 @@ impl Store {
                     scope: row.get(2)?,
                     project: row.get(3)?,
                     static_tokens: row.get(4)?,
-                    load_mode: row.get(5)?,
-                    uses: row.get(6)?,
+                    startup_tokens: row.get(5)?,
+                    load_mode: row.get(6)?,
+                    uses: row.get(7)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -876,13 +888,19 @@ impl Store {
         Ok(rows)
     }
 
-    /// Total always-on config tokens for a session in `project`: the global
-    /// figure plus that project's own startup-full config.
+    /// Total startup config tokens for a session in `project`: the global
+    /// figure plus that project's own startup cost.
+    ///
+    /// A surface installed at both scopes under the same `(kind, id)` is counted
+    /// twice here. Resolving that would mean asserting which copy Claude Code
+    /// actually loads, and the shadowing model this store implements is defined
+    /// for the **usage join** (`effective_catalog`), not for load order — a
+    /// project rule and its global namesake genuinely both reach the context, so
+    /// excluding one would understate the figure instead.
     pub fn always_on_config_tokens_for(&self, project: &str) -> Result<i64> {
         let total = self.conn.query_row(
-            "SELECT COALESCE(SUM(static_tokens), 0) FROM surfaces
-             WHERE load_mode = 'startup_full'
-               AND (scope = 'global' OR (scope = 'project' AND project = ?1))",
+            "SELECT COALESCE(SUM(startup_tokens), 0) FROM surfaces
+             WHERE scope = 'global' OR (scope = 'project' AND project = ?1)",
             [project],
             |row| row.get(0),
         )?;
@@ -1195,15 +1213,22 @@ mod tests {
         assert_eq!(usage[0].out_tokens, 999);
     }
 
-    fn surface(id: &str, scope: Scope, static_tokens: u64) -> Surface {
+    /// A skill surface whose body weighs `static_tokens` and whose description
+    /// (the only part loaded at startup) weighs `startup_tokens`.
+    fn skill_surface(id: &str, scope: Scope, static_tokens: u64, startup_tokens: u64) -> Surface {
         Surface {
             kind: "skill".to_string(),
             id: id.to_string(),
             scope,
             config_path: format!("/cfg/{id}"),
             static_tokens: Some(static_tokens),
+            startup_tokens: Some(startup_tokens),
             load_mode: LoadMode::StartupDescription,
         }
+    }
+
+    fn surface(id: &str, scope: Scope, static_tokens: u64) -> Surface {
+        skill_surface(id, scope, static_tokens, 0)
     }
 
     #[test]
@@ -1588,6 +1613,36 @@ mod tests {
         assert!(sql["events_by_surface"].contains("surface_kind"), "{sql:?}");
     }
 
+    #[test]
+    fn a_catalog_without_the_startup_cost_column_is_rebuilt() {
+        // A catalog weighed before startup cost was split out would silently
+        // answer every "what does removing this save" question with nothing, so
+        // it must not survive the upgrade as it is. `surfaces` is regenerated
+        // from live config on every analyze, so reconciling it costs nothing to
+        // drop — and clearing `analyzed_at` is what routes a `--frozen` read to
+        // the freshness warning instead of reporting the empty catalog as a
+        // finding.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE surfaces (kind TEXT NOT NULL, id TEXT NOT NULL,
+                                    scope TEXT NOT NULL, project TEXT NOT NULL,
+                                    static_tokens INTEGER, load_mode TEXT NOT NULL);
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO meta (key, value) VALUES ('analyzed_at', '2026-01-01T00:00:00Z');",
+        )
+        .unwrap();
+
+        let store = Store::from_connection(conn).expect("must migrate, not refuse");
+
+        let names: Vec<String> = table_shape(&store.conn, "surfaces")
+            .unwrap()
+            .into_iter()
+            .map(|column| column.name)
+            .collect();
+        assert!(names.contains(&"startup_tokens".to_string()), "{names:?}");
+        assert_eq!(store.meta("analyzed_at").unwrap(), None);
+    }
+
     fn span_at_ctx(skill: &str, ctx_start: u64) -> Span {
         Span {
             skill: skill.to_string(),
@@ -1711,7 +1766,7 @@ mod tests {
     }
 
     #[test]
-    fn always_on_config_sums_only_startup_full_surfaces() {
+    fn always_on_config_sums_every_surface_startup_cost() {
         let mut store = Store::in_memory().unwrap();
         store
             .replace_surfaces(&[
@@ -1721,6 +1776,7 @@ mod tests {
                     scope: Scope::Global,
                     config_path: "/c/CLAUDE.md".to_string(),
                     static_tokens: Some(600),
+                    startup_tokens: Some(600),
                     load_mode: LoadMode::StartupFull,
                 },
                 Surface {
@@ -1729,10 +1785,22 @@ mod tests {
                     scope: Scope::Global,
                     config_path: "/c/safety.md".to_string(),
                     static_tokens: Some(900),
+                    startup_tokens: Some(900),
                     load_mode: LoadMode::StartupFull,
                 },
-                // A skill is startup_description — must NOT count.
-                surface("git-commit", Scope::Global, 1000),
+                // A skill contributes its description, never its 1000-token body.
+                skill_surface("git-commit", Scope::Global, 1000, 8),
+                // An MCP server's schema is real but unweighable — it must not
+                // land in the sum as a false zero-cost row either way.
+                Surface {
+                    kind: "mcp_server".to_string(),
+                    id: "playwright".to_string(),
+                    scope: Scope::Global,
+                    config_path: "/c/.mcp.json".to_string(),
+                    static_tokens: None,
+                    startup_tokens: None,
+                    load_mode: LoadMode::ToolSchema,
+                },
                 // Another project's CLAUDE.md is always-on *there*, not globally.
                 Surface {
                     kind: "claude_md".to_string(),
@@ -1740,6 +1808,7 @@ mod tests {
                     scope: Scope::Project("alpha".to_string()),
                     config_path: "/tmp/example/CLAUDE.md".to_string(),
                     static_tokens: Some(400),
+                    startup_tokens: Some(400),
                     load_mode: LoadMode::StartupFull,
                 },
             ])
@@ -1747,8 +1816,20 @@ mod tests {
 
         // The global figure excludes project config; a session in alpha pays
         // the global floor plus alpha's own always-on config.
-        assert_eq!(store.always_on_config_tokens().unwrap(), 1500);
-        assert_eq!(store.always_on_config_tokens_for("alpha").unwrap(), 1900);
+        assert_eq!(store.always_on_config_tokens().unwrap(), 1508);
+        assert_eq!(store.always_on_config_tokens_for("alpha").unwrap(), 1908);
+    }
+
+    #[test]
+    fn the_catalog_carries_startup_and_body_cost_apart() {
+        let mut store = Store::in_memory().unwrap();
+        store
+            .replace_surfaces(&[skill_surface("repro", Scope::Global, 1015, 7)])
+            .unwrap();
+
+        let catalog = store.effective_catalog().unwrap();
+        assert_eq!(catalog[0].static_tokens, Some(1015));
+        assert_eq!(catalog[0].startup_tokens, Some(7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Measure a surface's **startup cost** separately from its whole definition: `startup_tokens` is the slice each load mode actually injects at session start (the whole text for an always-on file, the frontmatter `description` for a skill or agent, nothing for a body that waits on a path match, unknown for an MCP server), stored in a new `surfaces.startup_tokens` column.
- Report the two costs apart everywhere. The `optimize` briefing now reads `skill/x (~7 tok at startup / 1015 tok when invoked)`, `waste` shows the measured description in place of a flat `~0`, `inventory` gains a `start tok` column, and an MCP server whose schema weight is unknown says so instead of showing a figure.
- Fix the always-on accounting: `always_on_config_tokens` summed `static_tokens` over `startup_full` rows only, so every skill and agent description — real context, paid at every session start — was missing from the figure reconciled against the observed floor. `overhead`'s label is updated to match what it now sums.

## Why

Closes #8. Under "Global config to trim", an unused skill was rendered as `skill/repro (1015 tok)`, where the number reads as what deleting it reclaims. That figure is the body's cost **when invoked** — an unused skill has never paid it, and removing it frees only the description, some 7 tokens. The briefing seeds an advisor session that acts on these figures, so a body size printed as a trim saving becomes a fix proposal that frees nothing.

The domain model already had the distinction (`StartupSavings`, and `waste` honoured it), but `config_wedges` dropped the load mode when building a `SurfaceRef`, collapsing both costs into one field. Rather than only labelling the briefing's figures, this measures the startup half so the honest number can actually be shown — which also closes a second gap in the same direction: skill and agent descriptions are always-on context that the config-vs-floor reconciliation was attributing to nothing at all.

`docs/specs/{config-format,storage,surfaces,cli}.md` are updated in the same change, per `.claude/rules/spec-sync.md`.

## Test Plan

- [x] `cargo test` — 151 passed, including new unit tests for description weighing (plain / quoted / block-scalar / wrapped / commented / absent), the cost split in the catalog, the always-on sum, and the briefing's rendering
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`
- [x] Ran the issue's reproduction end to end (`analyze` → `sql` → `optimize --print` / `waste` / `inventory`) against a real config tree

## Note for reviewers

A store written by an earlier version lacks the new column and is refused with the existing "delete the db and re-run `cclens analyze`" guidance. `doctor --format json` changes shape: `unused[]` / `always_on_heavy[]` now carry `startup_tokens` + `on_demand_tokens` instead of `static_tokens`; `waste --format json` keeps its existing keys and adds both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3e6jA1j46xNRXowuM9qQd
