### PR TITLE
fix: build on Windows and cut paths on either separator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,24 @@ jobs:
           # image, which is on its way out. `cc` passes `-arch x86_64` for this
           # triple, which is all bundled SQLite needs.
           - { target: x86_64-apple-darwin, os: macos-latest }
-          # No Windows targets. The crate builds and runs on Windows, but
-          # nothing here would deliver the result: there is no tap to point at
-          # it, the archive step assumes tar, and no one has asked for a
-          # binary. Until one of those changes, Windows users build from source.
+          # Windows falls back to `USERPROFILE` when a shell leaves `HOME` unset,
+          # so the binary finds `~/.claude` and starts like it does anywhere
+          # else. Being in this matrix is also what keeps it that way: the
+          # `#[cfg(unix)]` gates compile away silently on every other target, so
+          # the next unix-only API added to the crate fails here rather than
+          # reaching a user. Both arches build natively, as Linux does — the
+          # arm64 image is free to public repositories, which this one is.
+          - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
     # The tag reaches the steps through the environment rather than being
     # interpolated into a script, so its text can never be read as shell.
     env:
       TAG: ${{ inputs.tag }}
+    # Git Bash on the Windows runner, whose default is PowerShell — one script
+    # per step then covers every target instead of branching on the shell.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -59,11 +69,17 @@ jobs:
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       # The archive name carries the tag and the triple so the Homebrew formula
-      # can address it by URL without consulting the releases API.
+      # can address it by URL without consulting the releases API. `.tar.gz` for
+      # Windows too, rather than the `.zip` that platform expects: the release
+      # job's checksum loop and the tap both address archives by that suffix, and
+      # a second format would fork both for the one target neither installs.
       - name: Package
         run: |
+          set -euo pipefail
+          bin=cclens
+          if [ "$RUNNER_OS" = Windows ]; then bin=cclens.exe; fi
           tar -C "target/${{ matrix.target }}/release" -czf \
-            "cclens-${TAG}-${{ matrix.target }}.tar.gz" cclens
+            "cclens-${TAG}-${{ matrix.target }}.tar.gz" "$bin"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
           # image, which is on its way out. `cc` passes `-arch x86_64` for this
           # triple, which is all bundled SQLite needs.
           - { target: x86_64-apple-darwin, os: macos-latest }
-          # No Windows targets. `~/.claude` is resolved through the HOME
-          # environment variable, which Windows does not set, so every default
-          # invocation would fail before it found a transcript. Shipping a
-          # binary that cannot start is worse than shipping none.
+          # No Windows targets. The crate builds and runs on Windows, but
+          # nothing here would deliver the result: there is no tap to point at
+          # it, the archive step assumes tar, and no one has asked for a
+          # binary. Until one of those changes, Windows users build from source.
     # The tag reaches the steps through the environment rather than being
     # interpolated into a script, so its text can never be read as shell.
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           # which is the storage growth this cache cannot afford.
           cachix pin cclens "release-${{ matrix.system }}" "$out" --keep-revisions 3
 
-  # One job owns the upload so the four builds cannot race, and so the checksums
+  # One job owns the upload so the matrix builds cannot race, and so the checksums
   # are computed from exactly the bytes that get attached.
   release:
     name: attach assets
@@ -178,8 +178,8 @@ jobs:
       # Install the rendered formula before publishing it. A URL typo, a sha256
       # paired with the wrong triple, or a binary that will not start all reach
       # the tap otherwise, and users are the ones who discover it. Only the
-      # Linux x86_64 archive is downloaded and installed here; the other three
-      # are rendered by the same loop but never fetched.
+      # Linux x86_64 archive is downloaded and installed here; the other triples
+      # the formula names are rendered by the same loop but never fetched.
       - name: Verify formula
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ macOS (x86_64 and arm64 each), attaches them to that release with `.sha256`
 files, and points the
 [`lambdalisue/homebrew-cclens`](https://github.com/lambdalisue/homebrew-cclens)
 tap at the new archives. The release is published before its assets are built,
-so the notes are visible for a few minutes with nothing attached yet. Windows is
-not supported: `~/.claude` is located through the `HOME` environment variable,
-which Windows does not set.
+so the notes are visible for a few minutes with nothing attached yet.
+
+No Windows binaries are published, but the crate builds and runs there from
+source. `~/.claude` is located through `HOME`, falling back to `USERPROFILE`
+where Windows leaves `HOME` unset.
 
 ## Claude Code plugin
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ just build           # release binary at target/release/cclens
 Plain Cargo also works (`cargo build --release`) if you have a recent stable
 Rust; the flake just pins it. CI runs `nix develop -c just check` / `just test`.
 
-Publishing a GitHub Release for a `vX.Y.Z` tag builds binaries for Linux and
-macOS (x86_64 and arm64 each), attaches them to that release with `.sha256`
-files, and points the
+Publishing a GitHub Release for a `vX.Y.Z` tag builds binaries for Linux, macOS,
+and Windows (x86_64 and arm64 each), attaches them to that release with
+`.sha256` files, and points the
 [`lambdalisue/homebrew-cclens`](https://github.com/lambdalisue/homebrew-cclens)
 tap at the new archives. The release is published before its assets are built,
 so the notes are visible for a few minutes with nothing attached yet.
 
-No Windows binaries are published, but the crate builds and runs there from
-source. `~/.claude` is located through `HOME`, falling back to `USERPROFILE`
-where Windows leaves `HOME` unset.
+The tap covers Linux and macOS only; on Windows, take the `-pc-windows-msvc`
+archive for your arch from the release, or build from source. `~/.claude` is
+located through `HOME`, falling back to `USERPROFILE` where Windows leaves
+`HOME` unset.
 
 ## Claude Code plugin
 

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -222,10 +222,14 @@ what stops the seeded session from re-deriving what `analyze` already computed.
 
 **The briefing is never passed on argv.** It holds concrete paths and error
 excerpts that may be sensitive, and a process argument is world-visible (`ps`).
-So the launch writes the briefing to a private (`0600`) temp file and passes
-`claude` only a data-free pointer prompt (the prescribed instructions plus "read
-this file"); the file is removed the instant the session ends, whatever the
-outcome. `--print` is the exception — it writes the full prompt (briefing inline)
+So the launch writes the briefing to a private temp file and passes `claude`
+only a data-free pointer prompt (the prescribed instructions plus "read this
+file"); the file is removed the instant the session ends, whatever the outcome.
+Private means **created exclusively** first and `0600` second: the temp dir is
+shared, so a same-user process that pre-creates the path as a symlink would
+capture the briefing no matter what mode was set afterwards. Where there is no
+mode to set (Windows), the per-user temp directory carries the guarantee
+instead. `--print` is the exception — it writes the full prompt (briefing inline)
 to stdout for piping / inspection, where the user has opted into seeing it.
 
 The split mirrors the rest of the tool: prompt composition is a pure transform

--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -54,6 +54,11 @@ Two kinds carry caveats that downstream reports must honour:
 - **`file_edit`** stores the basename *and* the full path because the two answer
   different questions. A hotspot ranking wants the basename — it is the name a
   human recognises, and collapsing every `route.ts` into one row is the point.
+  The name is taken on **either separator** (`core::path::basename`): a
+  transcript spells paths the way the machine that wrote it does, and the same
+  file arrives both ways within one session. Cutting on `/` alone left a
+  backslash path standing in for the name and let one file compete against
+  itself for a hotspot slot, so the list ranked spellings rather than files.
   Thrash detection wants the opposite: an episode claims *one agent kept retrying
   this one file*, so it must distinguish two same-named files, and two sessions
   editing one file in parallel. Keeping only the basename made those

--- a/docs/specs/storage.md
+++ b/docs/specs/storage.md
@@ -151,6 +151,13 @@ and folding is idempotent** (folding an already-folded value is a no-op). Gettin
 this wrong splits or merges a project's usage, which is a correctness bug for
 every per-project wedge, not a presentation detail.
 
+`sessions.root` folds by the same rule one level down, on the real path rather
+than the slug. The two must agree: the slug form keys on a `--wt-` infix and is
+separator-free, so the path form accepts **either separator** — otherwise a
+worktree recorded on Windows folds by `project` while `root` stays split, and
+per-root config scanning (`config-format.md`) sees two roots where there is one
+checkout.
+
 ## Incremental ingest
 
 Transcripts are append-only and **active sessions keep growing**, so re-running

--- a/src/adapter/transcript.rs
+++ b/src/adapter/transcript.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::core::friction::{ErrorCategory, classify_error};
+use crate::core::path::basename;
 use crate::core::prompt::{PromptBehavior, classify_prompt};
 use crate::core::span::{Record, RecordKind, Source};
 
@@ -415,7 +416,7 @@ pub fn extract_work_events(jsonl: &str) -> Vec<WorkEvent> {
                         events.push(WorkEvent {
                             epoch_ms: ts,
                             kind: "file_edit",
-                            id: path.rsplit('/').next().unwrap_or(path).to_string(),
+                            id: basename(path).to_string(),
                             path: Some(path.to_string()),
                         });
                     }
@@ -603,6 +604,23 @@ mod tests {
         // The full path rides along so thrash detection can tell two same-named
         // files apart.
         assert_eq!(events[1].path.as_deref(), Some("/a/b/cli.rs"));
+    }
+
+    #[test]
+    fn work_events_take_the_edit_basename_from_a_backslash_path() {
+        // A transcript written on Windows spells the target natively, and the
+        // same file also arrives with forward slashes. Both must land on one id
+        // or the hotspot list ranks spellings instead of files.
+        let jsonl = concat!(
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"C:\\example\\repo\\cli.rs"}}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"repo/cli.rs"}}]}}"#,
+        );
+        let events = extract_work_events(jsonl);
+        assert_eq!(events[0].id, "cli.rs");
+        assert_eq!(events[1].id, "cli.rs");
+        // The full path still distinguishes them for thrash detection.
+        assert_eq!(events[0].path.as_deref(), Some(r"C:\example\repo\cli.rs"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -365,23 +365,49 @@ fn optimize(
     Ok(())
 }
 
-/// Write `contents` to a uniquely-named file in the temp dir, readable only by
-/// the current user (`0600`). Used for the optimization briefing, which may hold
-/// sensitive paths/excerpts and must not sit on argv or be world-readable.
+/// Write `contents` to a fresh file in the temp dir. Used for the optimization
+/// briefing, which may hold sensitive paths/excerpts and must not sit on argv or
+/// be world-readable.
 fn write_private_tempfile(contents: &str) -> Result<PathBuf> {
-    use std::io::Write;
-    use std::os::unix::fs::OpenOptionsExt;
-
+    // The clock is here to avoid a collision with a leftover file, not to be
+    // unguessable — exclusive creation is what makes guessing the name useless.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_nanos());
     let mut path = std::env::temp_dir();
-    path.push(format!("cclens-briefing-{}.md", std::process::id()));
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(&path)?;
-    file.write_all(contents.as_bytes())?;
+    path.push(format!(
+        "cclens-briefing-{}-{nanos:x}.md",
+        std::process::id()
+    ));
+    write_private_file(&path, contents)?;
     Ok(path)
+}
+
+/// Create `path` and write `contents` to it, for the current user only.
+///
+/// The temp dir is shared on unix, so the file has to be **created
+/// exclusively**: a same-user process that pre-creates the path — as a symlink
+/// to somewhere it can read — would otherwise capture the briefing, and no
+/// permission bits set afterwards would help. Losing that race now fails the
+/// open instead of following what is already there.
+///
+/// `0600` narrows it further on unix. Windows has no mode to set here; the
+/// default per-user `%LOCALAPPDATA%\Temp` is what keeps other unprivileged
+/// users out, so the guarantee there rests on the directory rather than the
+/// file. Setting an explicit ACL would mean a new dependency for a second lock
+/// on a door that is already locked.
+fn write_private_file(path: &Path, contents: &str) -> Result<()> {
+    use std::io::Write;
+
+    let mut opts = fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)?.write_all(contents.as_bytes())?;
+    Ok(())
 }
 
 /// Gather the COMPLETE analysis the optimization briefing carries — every view's
@@ -1009,14 +1035,29 @@ fn preamble(format: Format, text: &str) {
     }
 }
 
-/// Shorten an absolute path under $HOME to `~/…` for display.
+/// Shorten an absolute path under the home directory to `~/…` for display.
 fn tilde_path(path: &str) -> String {
-    match std::env::var("HOME") {
-        Ok(home) if !home.is_empty() => match path.strip_prefix(&home) {
-            Some("") => "~".to_string(),
-            Some(rest) if rest.starts_with('/') => format!("~{rest}"),
-            _ => path.to_string(),
-        },
+    shorten_to_tilde(path, home_dir())
+}
+
+/// The shortening itself, separated from the environment lookup so it stays
+/// pure and testable. A separator must follow the prefix, so `/home/metadata`
+/// is not mistaken for something under `/home/me`; either separator counts, so
+/// a Windows path shortens against a Windows home.
+fn shorten_to_tilde(path: &str, home: Option<&str>) -> String {
+    let Some(home) = home.filter(|home| !home.is_empty()) else {
+        return path.to_string();
+    };
+    // The two sides come from different places — `home` from the environment,
+    // `path` from the cwd a transcript recorded — so on Windows they can spell
+    // the same directory differently; the OS accepts either. Only the
+    // comparison is folded. The suffix is sliced from the original at the same
+    // offset, which stays valid because folding swaps one ASCII byte for
+    // another, so the display keeps whatever spelling the path really had.
+    let fold = |s: &str| s.replace('\\', "/");
+    match fold(path).strip_prefix(&fold(home)) {
+        Some("") => "~".to_string(),
+        Some(rest) if rest.starts_with('/') => format!("~{}", &path[home.len()..]),
         _ => path.to_string(),
     }
 }
@@ -2195,8 +2236,39 @@ fn default_projects_dir() -> Result<PathBuf> {
     Ok(claude_home()?.join("projects"))
 }
 
+/// The user's home directory, resolved once per run.
+///
+/// `HOME` is preferred, so unix behaves exactly as before; Windows does not set
+/// it, hence `USERPROFILE`. The wrinkle is that a Windows shell like Git Bash
+/// *does* export `HOME` — as a POSIX path (`/c/Users/…`) that a native binary
+/// cannot resolve. Taking it at face value would send every lookup to a
+/// directory that does not exist and report "no transcripts" instead of an
+/// error, so on Windows a candidate has to name a real directory to win. The
+/// check stays off on unix, where a home that does not exist is worth surfacing
+/// as itself rather than silently falling through to another variable.
+fn home_dir() -> Option<&'static str> {
+    static HOME: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    HOME.get_or_init(|| {
+        ["HOME", "USERPROFILE"]
+            .into_iter()
+            .filter_map(|key| std::env::var(key).ok())
+            .filter(|value| !value.is_empty())
+            .find(|value| !cfg!(windows) || Path::new(value).is_dir())
+    })
+    .as_deref()
+}
+
 fn claude_home() -> Result<PathBuf> {
-    let home = std::env::var("HOME").context("HOME is not set")?;
+    // What can go wrong differs by platform, so the advice does too: only
+    // Windows requires the value to name a real directory, and telling a unix
+    // user otherwise sends them looking for a problem they do not have.
+    let home = home_dir().with_context(|| {
+        if cfg!(windows) {
+            "set HOME or USERPROFILE to an existing directory"
+        } else {
+            "HOME is not set"
+        }
+    })?;
     Ok(PathBuf::from(home).join(".claude"))
 }
 
@@ -2351,6 +2423,118 @@ fn pad(text: &str, width: usize, align: Align) -> String {
 mod tests {
     use super::*;
 
+    /// A path in the temp dir that no other test uses, removed on drop so a
+    /// failure does not leak a file into the runner's temp dir.
+    struct TempPath(PathBuf);
+
+    impl TempPath {
+        fn new(tag: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("cclens-test-{}-{tag}", std::process::id()));
+            let _ = fs::remove_file(&path);
+            Self(path)
+        }
+    }
+
+    impl Drop for TempPath {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
+
+    #[test]
+    fn write_private_file_refuses_a_path_that_already_exists() {
+        // The temp dir is shared, so a same-user process can pre-create the
+        // path — as a symlink to somewhere it can read. Writing the briefing
+        // into whatever is already there is the leak this prevents.
+        let path = TempPath::new("preexisting.md");
+        fs::write(&path.0, "squatted").unwrap();
+        assert!(write_private_file(&path.0, "briefing").is_err());
+        assert_eq!(fs::read_to_string(&path.0).unwrap(), "squatted");
+    }
+
+    #[test]
+    fn write_private_file_writes_the_contents_to_a_fresh_path() {
+        let path = TempPath::new("fresh.md");
+        write_private_file(&path.0, "briefing").unwrap();
+        assert_eq!(fs::read_to_string(&path.0).unwrap(), "briefing");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_file_is_readable_only_by_its_owner() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = TempPath::new("mode.md");
+        write_private_file(&path.0, "briefing").unwrap();
+        let mode = fs::metadata(&path.0).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn shorten_to_tilde_replaces_the_home_prefix() {
+        assert_eq!(
+            shorten_to_tilde("/tmp/example/me/.claude", Some("/tmp/example/me")),
+            "~/.claude"
+        );
+        // Home itself collapses to a bare tilde.
+        assert_eq!(
+            shorten_to_tilde("/tmp/example/me", Some("/tmp/example/me")),
+            "~"
+        );
+    }
+
+    #[test]
+    fn shorten_to_tilde_accepts_a_backslash_separator() {
+        assert_eq!(
+            shorten_to_tilde(r"C:\example\me\.claude", Some(r"C:\example\me")),
+            r"~\.claude"
+        );
+    }
+
+    #[test]
+    fn shorten_to_tilde_matches_a_home_spelled_with_the_other_separator() {
+        // Windows takes either separator, and the home comes from the
+        // environment while the path comes from a recorded cwd — so the two can
+        // disagree on spelling while naming the same directory.
+        assert_eq!(
+            shorten_to_tilde("C:/example/me/.claude", Some(r"C:\example\me")),
+            "~/.claude"
+        );
+        assert_eq!(
+            shorten_to_tilde(r"C:\example\me\.claude", Some("C:/example/me")),
+            r"~\.claude"
+        );
+        // The suffix keeps the spelling the path actually had, not the folded
+        // one used for the comparison.
+        assert_eq!(
+            shorten_to_tilde(r"C:\example\me\a/b\c", Some("C:/example/me")),
+            r"~\a/b\c"
+        );
+    }
+
+    #[test]
+    fn shorten_to_tilde_leaves_a_path_outside_home_alone() {
+        assert_eq!(
+            shorten_to_tilde("/tmp/other", Some("/tmp/example/me")),
+            "/tmp/other"
+        );
+        // A sibling that merely shares the prefix is not under home.
+        assert_eq!(
+            shorten_to_tilde("/tmp/example/metadata", Some("/tmp/example/me")),
+            "/tmp/example/metadata"
+        );
+    }
+
+    #[test]
+    fn shorten_to_tilde_passes_the_path_through_without_a_home() {
+        assert_eq!(shorten_to_tilde("/tmp/example/me", None), "/tmp/example/me");
+        assert_eq!(
+            shorten_to_tilde("/tmp/example/me", Some("")),
+            "/tmp/example/me"
+        );
+    }
+
     #[test]
     fn normalize_root_folds_a_worktree_path_onto_its_repo() {
         assert_eq!(
@@ -2360,4 +2544,5 @@ mod tests {
         // Idempotent: an already-folded root stays put.
         assert_eq!(normalize_root("/tmp/example/repo"), "/tmp/example/repo");
     }
+
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1686,11 +1686,31 @@ fn file_fingerprint(path: &Path) -> Option<(i64, i64)> {
 
 /// Fold a worktree checkout's path onto its parent repository, mirroring
 /// `normalize_project`'s slug rule at path level: `/repo/.wt/feat-x` → `/repo`.
+///
+/// Either separator delimits the segment, so a cwd recorded on Windows
+/// (`C:\repo\.wt\feat-x`) folds like a unix one. The slug rule keys on `--wt-`
+/// and is separator-free, so without this the two halves of the same
+/// normalization disagreed and a project folded by slug stayed split by root.
 fn normalize_root(cwd: &str) -> String {
-    match cwd.split_once("/.wt/") {
-        Some((parent, _)) => parent.to_string(),
-        None => cwd.to_string(),
+    const SEGMENT: &str = ".wt";
+    for (idx, _) in cwd.match_indices(SEGMENT) {
+        let has_parent = cwd[..idx].ends_with(['/', '\\']);
+        let has_child = cwd[idx + SEGMENT.len()..].starts_with(['/', '\\']);
+        if has_parent && has_child {
+            // `idx` is at least 1 here, and the separator before it is one byte.
+            let parent = &cwd[..idx - 1];
+            // Directly under a filesystem root there is no parent to fold onto:
+            // the separator *is* the root, so dropping it would turn `/.wt/x`
+            // into `""` and `C:\.wt\x` into a drive-relative `C:`. A drive
+            // prefix is exactly two bytes, which keeps an ordinary directory
+            // whose name ends in a colon out of this branch.
+            if parent.is_empty() || (parent.len() == 2 && parent.ends_with(':')) {
+                return cwd[..idx].to_string();
+            }
+            return parent.to_string();
+        }
     }
+    cwd.to_string()
 }
 
 /// The `(prompt_id, output_tokens)` of each of a session's subagent transcripts,
@@ -2545,4 +2565,40 @@ mod tests {
         assert_eq!(normalize_root("/tmp/example/repo"), "/tmp/example/repo");
     }
 
+    #[test]
+    fn normalize_root_folds_a_backslash_worktree_path() {
+        // A cwd recorded on Windows spells the same layout natively; leaving it
+        // unfolded splits a project whose slug already folded.
+        assert_eq!(
+            normalize_root(r"C:\example\repo\.wt\feat-x"),
+            r"C:\example\repo"
+        );
+        assert_eq!(normalize_root(r"C:\example\repo"), r"C:\example\repo");
+    }
+
+    #[test]
+    fn normalize_root_keeps_the_filesystem_root_separator() {
+        // Folding onto the root leaves the separator standing: it *is* the
+        // parent. Dropping it would hand back a relative path — `""` on unix,
+        // the drive-relative `C:` on Windows — and the root then names a
+        // different directory than the one the session ran in.
+        assert_eq!(normalize_root("/.wt/feat-x"), "/");
+        assert_eq!(normalize_root(r"C:\.wt\feat-x"), r"C:\");
+        // A directory whose name merely ends in a colon is not a drive.
+        assert_eq!(normalize_root("/tmp/odd:/.wt/feat-x"), "/tmp/odd:");
+    }
+
+    #[test]
+    fn normalize_root_leaves_a_dot_wt_that_is_not_a_segment_alone() {
+        // Only a whole `.wt` directory is a worktree parent.
+        assert_eq!(
+            normalize_root("/tmp/example/repo/x.wt/feat-x"),
+            "/tmp/example/repo/x.wt/feat-x"
+        );
+        // A trailing `.wt` names no checkout to fold onto.
+        assert_eq!(
+            normalize_root("/tmp/example/repo/.wt"),
+            "/tmp/example/repo/.wt"
+        );
+    }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -5,6 +5,7 @@ pub mod bucket;
 pub mod friction;
 pub mod metrics;
 pub mod optimize;
+pub mod path;
 pub mod prompt;
 pub mod scope;
 pub mod span;

--- a/src/core/path.rs
+++ b/src/core/path.rs
@@ -1,0 +1,51 @@
+//! Path helpers shared by the analysis core and the adapter that feeds it.
+
+/// The last segment of `path`, treating both `/` and `\` as separators.
+///
+/// A transcript carries whatever separator the machine that wrote it uses, and
+/// within one session the same file arrives spelled both ways — one tool call
+/// passes `docs/tasks.md`, the next passes `D:\notes\docs\tasks.md`. Splitting
+/// on `/` alone left the whole path standing in for the name and let a single
+/// file compete against itself for a hotspot slot, ranking on how the path
+/// happened to be spelled rather than on the file.
+///
+/// Accepting both separators everywhere mis-splits a unix filename that really
+/// contains a backslash. That is the far rarer case, and this label is
+/// deliberately lossy already — the full path is kept alongside it for anything
+/// that must tell two same-named files apart (`docs/specs/events.md`).
+pub fn basename(path: &str) -> &str {
+    match path.rsplit_once(['/', '\\']) {
+        Some((_, name)) => name,
+        None => path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basename_takes_the_last_segment() {
+        assert_eq!(basename("/tmp/example/repo/src/main.rs"), "main.rs");
+    }
+
+    #[test]
+    fn basename_accepts_a_backslash_separator() {
+        assert_eq!(basename(r"C:\example\repo\src\main.rs"), "main.rs");
+    }
+
+    #[test]
+    fn basename_folds_both_spellings_of_one_file_together() {
+        // The hotspot grouping key: however the path was spelled, one file is
+        // one row.
+        assert_eq!(
+            basename(r"D:\notes\docs\tasks.md"),
+            basename("docs/tasks.md")
+        );
+    }
+
+    #[test]
+    fn basename_passes_a_bare_name_through() {
+        assert_eq!(basename("tasks.md"), "tasks.md");
+    }
+}

--- a/src/core/thrash.rs
+++ b/src/core/thrash.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashMap;
 
+use crate::core::path::basename;
+
 /// One edit to one file, with the work context that makes it comparable to
 /// another edit: the same path touched by a different session is different work.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -37,7 +39,7 @@ impl ThrashEpisode {
     /// The edited file's basename — what a report shows; the full `path`
     /// disambiguates when two projects share a name.
     pub fn file(&self) -> &str {
-        self.path.rsplit('/').next().unwrap_or(&self.path)
+        basename(&self.path)
     }
 }
 
@@ -156,6 +158,17 @@ mod tests {
         assert_eq!(episodes.len(), 1);
         assert_eq!(episodes[0].edits, 3);
         assert_eq!(episodes[0].span_secs(), 50);
+        assert_eq!(episodes[0].file(), "a.rs");
+    }
+
+    #[test]
+    fn the_reported_file_is_a_basename_on_either_separator() {
+        let edits = [
+            edit(r"C:\example\p\a.rs", 0),
+            edit(r"C:\example\p\a.rs", 30),
+            edit(r"C:\example\p\a.rs", 50),
+        ];
+        let episodes = detect_thrash(&edits, 60, 3);
         assert_eq!(episodes[0].file(), "a.rs");
     }
 


### PR DESCRIPTION
## Summary

- Gate the briefing temp file's `0600` behind `#[cfg(unix)]` so the crate compiles for Windows, and make **exclusive creation** the guard that actually protects it on both platforms
- Resolve `~/.claude` through `HOME`, falling back to `USERPROFILE`, with a Windows-only requirement that the value name a real directory
- Take a path's last segment on **either** separator, through one shared helper, so the file-edit hotspot id is a basename on Windows and one file stops splitting into two rows
- Fold a worktree `root` on either separator, so it agrees with the separator-free slug rule
- Add a Windows CI job (plain cargo, since Nix cannot host it) so the `cfg` gates cannot rot unnoticed

Closes #10.

## Why

The crate did not compile for Windows at all — the optimization briefing set `0600` through a unix-only trait imported unconditionally — and `~/.claude` was located through `HOME`, which Windows does not set. Both were reported with measurements in #10.

Gating the mode raised a question the previous code had quietly avoided. On unix the temp dir is shared, so the mode was never the real guarantee: a same-user process that pre-creates the path as a symlink captures the briefing whatever mode is set afterwards. Exclusive creation is the guard on both platforms; the mode narrows it further where there is one to set, and on Windows the per-user temp directory carries the rest. Setting an explicit ACL would mean a new dependency for a second lock on a door that is already locked.

For the home lookup, preferring `HOME` unconditionally would trade one failure for a worse one: Git Bash and MSYS *do* export `HOME`, as a POSIX path (`/c/Users/...`) that a native binary cannot resolve, so the tool would report "no transcripts" instead of an error. Requiring a candidate to name a real directory — on Windows only — covers both shells and leaves unix behaviour untouched.

The separator handling is the half that fails silently, which is why it matters more than the build break. Claude Code writes native paths into its transcripts, so cutting on `/` alone left the whole string standing in for the basename — and within one session the same file arrives spelled both ways, one call passing `docs/tasks.md` and the next `D:\notes\docs\tasks.md`. A store measured on Windows shows 102 edits under the absolute spelling and 44 under the bare name, for one file. The hotspot list therefore ranked spellings rather than files, with a file competing against itself for the top slots. Worktree folding had the same shape: the slug rule is separator-free, so a Windows worktree folded by `project` while its `root` stayed split.

Both fixes compile away to nothing on unix, so nothing in CI would notice when the next unix-only API breaks them — hence the Windows job.

No binaries are published for Windows: nothing in the release pipeline would deliver one, and no one has asked. Building from source is the supported route, so the README now says that rather than "not supported".

## Credit

This is a re-implementation, not a merge, but the analysis is not ours:

- **@ethfumi** (#10) — measured the two blockers on Windows 11 (`x86_64-pc-windows-gnu`), and found the POSIX-`HOME` trap that a naive `USERPROFILE` fallback walks into. The home lookup here follows their branch.
- **@Just2enough** (#10) — reproduced on `x86_64-pc-windows-msvc`, then found both silent divergences against real transcripts, including the 102/44 split above.
- **@921108257** (#13) — the exclusive-creation hardening for the briefing temp file, which is worth having on unix independently of Windows.

## Test Plan

- [x] `just check` (rustfmt + clippy `-D warnings`) clean
- [x] `just test` — 150 passed (135 before; +15 covering the basename helper, both call sites, worktree folding on either separator, the tilde shortening, and the temp file's exclusive creation and mode)
- [x] The non-unix compilation path checked by temporarily inverting the `cfg` predicate — the Nix toolchain carries no Windows std, so this stands in for a cross-compile
- [x] Smoke-tested against real transcripts on macOS: `analyze`, `doctor` and `stuck` unchanged, hotspot ids still basenames
- [ ] The new Windows CI job — first real run is on this PR
- [ ] `cclens optimize` (without `--print`) on Windows: `Command::new("claude")` is untouched here, and Rust's std does not consult `PATHEXT`, so an npm-installed `claude.cmd` may not resolve. Unverified — no Windows machine on this end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrtSJQdYyJ4sq65GKgScbk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows build support for x86_64 and ARM64 targets.
  * Windows paths are now handled consistently across home-directory resolution, project normalization, file tracking, and session storage.
* **Bug Fixes**
  * Prevented unsafe overwriting or symlink following when creating private optimization files.
  * Unified file tracking for equivalent Windows and Unix path formats.
* **Documentation**
  * Updated Windows installation guidance and path-handling specifications.
* **Chores**
  * Improved release workflow comments and Windows packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->