### PR TITLE
Report a partial per-agent subagent split as partial

### DIFF
--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -93,9 +93,9 @@ ranking.
 
 | View | Answers |
 | --- | --- |
-| `doctor` | The entry point: a one-screen health check **written for someone who has never seen cclens's vocabulary** — every item says what happened, why it costs, and what to do. Sections: `WHAT TO FIX FIRST` (recurring problems as a prioritized to-do list, each routed to the owning config layer with the follow-up command), `COST` (the session-start context and output totals in plain words, humanized units, naming the agent types behind the subagent figure), `CONFIG WORTH PRUNING` (dead or heavy config per owner), `LOOKS HEALTHY` (what explicitly needs no action). `--scope` narrows to one layer; the text form leads with actions, never a stats dump. |
+| `doctor` | The entry point: a one-screen health check **written for someone who has never seen cclens's vocabulary** — every item says what happened, why it costs, and what to do. Sections: `WHAT TO FIX FIRST` (recurring problems as a prioritized to-do list, each routed to the owning config layer with the follow-up command), `COST` (the session-start context and output totals in plain words, humanized units, naming the agent types behind the subagent figure — and, when the named rows cover only part of that figure, saying so first; see *Reporting honesty*), `CONFIG WORTH PRUNING` (dead or heavy config per owner), `LOOKS HEALTHY` (what explicitly needs no action). `--scope` narrows to one layer; the text form leads with actions, never a stats dump. |
 | `inventory` | The catalog×usage join per surface **row** (scope and owning project shown; usage attributed under per-project shadowing — `surfaces.md`): startup cost, static cost, load mode, usage. `--scope` filters to one layer; orphaned usage (no scope to filter on) appears in the unfiltered view only. |
-| `usage` | Skill event rollups: per skill, or per time bucket (`--by`) — frequency, tokens, `ctx_growth`, duration. Leads with a token-destination line (main-thread skill output vs subagent total) so the reader sees where tokens actually go before the table, then splits the subagent half **per agent type** (runs and output tokens, costliest first) — the aggregate is usually the larger number and the split is the part that can be acted on. A section with no rows is omitted rather than rendered as bare headers. |
+| `usage` | Skill event rollups: per skill, or per time bucket (`--by`) — frequency, tokens, `ctx_growth`, duration. Leads with a token-destination line (main-thread skill output vs subagent total) so the reader sees where tokens actually go before the table, then splits the subagent half **per agent type** (runs and output tokens, costliest first) — the aggregate is usually the larger number and the split is the part that can be acted on. JSON carries the split's coverage as `agent_split` in every state. In text, a partial split prints its covered and uncovered figures between the total and the table, an unavailable split (no rows at all) is warned on stderr, and rows that cover the total need no note (see *Reporting honesty*). A section with no rows is omitted rather than rendered as bare headers. |
 | `waste` | Just the flagged opportunities (unused, costly+rare, always-on heavy, …) with their evidence and owning scope; `--scope` filters to one layer. |
 | `overhead` | Reconcile the empirical always-on floor (the leanest observed **session start**, not the context a skill happened to run at — `surfaces.md`) against the readable always-on config; the residual is the system prompt + built-in tools + MCP schemas the catalog cannot weigh. The per-project table carries the session count behind each floor, because the floor is a minimum over observations and a project with few sessions may never have caught a fresh one. Reports the metric as unavailable when no session start was observed at all. |
 | `prompts` | How the user steers the session: the mix of steer / correct / question / instruct prompts (`core::prompt`, lexical heuristics), with a verdict — heavy steering suggests more autonomy, frequent correction suggests clearer upfront specs. This is a behavioral signal, not a config metric; embeddings showed prompt *topics* do not map to reusable skills, so the value is in *how* you prompt, not *what about*. |
@@ -165,12 +165,26 @@ caveats in `events.md` / `surfaces.md`):
   for "never installed".
 - A subagent run whose agent type was never recorded is shown as `(unknown)`,
   never merged into a named type and never dropped — the per-agent rows must
-  keep summing to the subagent total the same report prints above them.
+  keep summing to the subagent total the same report prints above them, for
+  every run that could be extracted (the two cases below cover the runs that
+  could not).
 - When they *cannot* sum to it — a store predating the per-agent split, read
   with `--frozen` so the refresh that would fill it never ran — the report says
   so on stderr instead of letting an absent breakdown pass for a zero one
   (`storage.md`'s report-the-gap contract). It rides with the freshness line
   rather than in the table, so piped stdout and `--format json` stay clean.
+- When they sum to only *part* of it — sessions analyzed before runs were
+  extracted keep their totals (`storage.md`: the store outlives its inputs), but
+  once Claude Code has pruned their transcripts no refresh can ever produce their
+  rows — the rows are labeled a **partial split** in-band, beside the numbers
+  they qualify, because this is a property of the data and not a staleness a
+  refresh could cure: `usage` prints the covered and uncovered figures between
+  the total and the table, `doctor` states the gap before naming any agent, the
+  briefing does the same under its subagent line, and JSON carries the
+  reconciliation as `agent_split` (`core::subagent::SplitCoverage`). `doctor`
+  introduces its top rows as "most of" the subagent output only when they
+  exceed half of the total — a long tail, or a partial split, gets a wording
+  that claims no more than the rows show.
 
 Meta-skills are not nested (`events.md`): a driver and the skills it ran are
 each their own span, so a child's cost lands on the child and no figure is

--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -195,7 +195,12 @@ run, and the **root** `tool_use_id` its tree started at (`core::subagent`).
 - **Every run counts once, at its own cost, whatever its depth.** A nested run
   is the agent that wrote those tokens; folding it into its parent's type would
   bill an agent that only delegated. So the per-agent rows sum exactly to the
-  session-level total.
+  session-level total — for every session whose runs could be extracted. A
+  session analyzed before runs were extracted keeps its total, but once Claude
+  Code has pruned its transcripts its runs are gone for good, so a store can
+  hold rows for only part of its total; reports reconcile the two and label
+  the rows a partial split (`core::subagent::SplitCoverage`, `cli.md`'s
+  reporting-honesty rules).
 - **A run whose agent type is unknown** (no sidecar) is kept, grouped under
   "unknown". Dropping it would silently break that sum; guessing a type would
   be worse.
@@ -279,7 +284,9 @@ skills that genuinely spawn their own agents) but is **not rolled up into the
 per-skill report**, where it would over-count. The authoritative subagent figure
 is the **session-level total** (`sessions.sub_tokens`), which is exact — every
 subagent run counted once, no window guess involved — and the per-agent split of
-that total (`subagent_runs`) is exact for the same reason.
+that total (`subagent_runs`) is exact for the same reason wherever it exists.
+The two are recorded separately, so the split can cover only part of the total
+in a store that outlived the transcripts behind it; see the runs section above.
 
 ## Determinism
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ use crate::core::friction::ErrorCategory;
 use crate::core::optimize as optimize_mod;
 use crate::core::scope::{ScopeFilter, split_friction};
 use crate::core::span::{DEFAULT_IDLE_GAP_MS, SessionStart, extract_spans, session_start};
-use crate::core::subagent::{SubagentRun, link_runs};
+use crate::core::subagent::{SplitCoverage, SubagentRun, link_runs};
 use crate::core::surface::{
     LoadMode, Scope, StartupSavings, Surface, Wedge, classify_wedge, is_usage_measurable,
     on_demand_tokens, startup_savings,
@@ -616,19 +616,25 @@ fn collect_findings(store: &Store) -> Result<optimize_mod::Findings> {
     };
 
     let (sub_tokens, sub_agents) = store.subagent_totals()?;
+    let agents: Vec<optimize_mod::AgentCost> = store
+        .subagent_by_agent()?
+        .into_iter()
+        .map(|row| optimize_mod::AgentCost {
+            agent: row.agent,
+            runs: row.runs,
+            out_tokens: row.out_tokens,
+        })
+        .collect();
     Ok(optimize_mod::Findings {
         main_out: store.skill_usage()?.iter().map(|r| r.out_tokens).sum(),
         sub_tokens,
         sub_agents,
-        agents: store
-            .subagent_by_agent()?
-            .into_iter()
-            .map(|row| optimize_mod::AgentCost {
-                agent: row.agent,
-                runs: row.runs,
-                out_tokens: row.out_tokens,
-            })
-            .collect(),
+        agent_split: SplitCoverage::new(
+            sub_tokens,
+            sub_agents,
+            agents.iter().map(|a| (a.runs, a.out_tokens)),
+        ),
+        agents,
         floor,
         config_tokens: if floor > 0 {
             store.always_on_config_tokens()?
@@ -942,39 +948,13 @@ fn doctor(filter: &ScopeFilter, format: Format, frozen: bool, db: &Path) -> Resu
             fmt_tokens(f.sub_tokens),
             f.sub_agents
         );
-        warn_missing_agent_split(f.sub_tokens, f.agents.is_empty());
-        // Name the agents behind that second figure — it is usually the larger
-        // one, and "which agent" is the actionable half of it.
-        let top: Vec<String> = f
-            .agents
-            .iter()
-            .take(3)
-            .map(|a| {
-                format!(
-                    "{} {} ({} run{})",
-                    a.label(),
-                    fmt_tokens(a.out_tokens),
-                    a.runs,
-                    if a.runs == 1 { "" } else { "s" }
-                )
-            })
-            .collect();
-        if !top.is_empty() {
-            println!(
-                "  Most of that subagent output: {}. Full split: {}",
-                top.join(", "),
-                style.command("cclens usage")
-            );
-        }
-        // Never truncate silently (reporting honesty, cli.md).
-        if f.agents.len() > top.len() {
-            println!(
-                "  {}",
-                style.dim(&format!(
-                    "… and {} more agent type(s) not shown",
-                    f.agents.len() - top.len()
-                ))
-            );
+        warn_missing_agent_split(&f.agent_split);
+        for line in doctor_agent_lines(&f, &style.command("cclens usage")) {
+            if line.starts_with('…') {
+                println!("  {}", style.dim(&line));
+            } else {
+                println!("  {line}");
+            }
         }
     }
 
@@ -1084,6 +1064,62 @@ fn plural(n: usize, noun: &str) -> String {
     } else {
         format!("{n} {noun}s")
     }
+}
+
+/// The doctor's lines naming the agents behind the subagent figure — "which
+/// agent" is the actionable half of it. The top rows are introduced as "most
+/// of" the output only when they actually exceed half of it; when the rows
+/// are a partial split (`SplitCoverage`), the gap is stated first so the
+/// names are not read as the whole bill. `full_split` is the styled command
+/// that shows every row. An unavailable split yields nothing: that case is
+/// reported on stderr with its refresh hint.
+fn doctor_agent_lines(f: &optimize_mod::Findings, full_split: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let top: Vec<String> = f
+        .agents
+        .iter()
+        .take(3)
+        .map(|a| {
+            format!(
+                "{} {} ({} run{})",
+                a.label(),
+                fmt_tokens(a.out_tokens),
+                a.runs,
+                if a.runs == 1 { "" } else { "s" }
+            )
+        })
+        .collect();
+    if top.is_empty() {
+        return lines;
+    }
+    let coverage = &f.agent_split;
+    let shown: i64 = f.agents.iter().take(top.len()).map(|a| a.out_tokens).sum();
+    let intro = if coverage.is_partial() {
+        lines.push(format!(
+            "Only {} of those tokens ({} of {} runs) have a per-agent split — the rest were \
+             analyzed before runs were extracted and their transcripts are gone.",
+            fmt_tokens(coverage.known_tokens),
+            coverage.known_runs,
+            coverage.total_runs
+        ));
+        "Among the runs that have one"
+    } else if coverage.is_majority(shown) {
+        "Most of that subagent output"
+    } else {
+        "The largest agent types"
+    };
+    lines.push(format!(
+        "{intro}: {}. Full split: {full_split}",
+        top.join(", ")
+    ));
+    // Never truncate silently (reporting honesty, cli.md).
+    if f.agents.len() > top.len() {
+        lines.push(format!(
+            "… and {} more agent type(s) not shown",
+            f.agents.len() - top.len()
+        ));
+    }
+    lines
 }
 
 /// Humanize a token count: `6467406` → `6.5M`, `32139` → `32.1k`.
@@ -1725,8 +1761,12 @@ fn open_for_read(db: &Path, frozen: bool) -> Result<Store> {
 /// is the substitution it forbids (`docs/specs/storage.md`). It goes to stderr
 /// with the other staleness signals, so piped stdout and `--format json` stay
 /// clean.
-fn warn_missing_agent_split(sub_tokens: i64, agents_empty: bool) {
-    if sub_tokens > 0 && agents_empty {
+///
+/// A *partial* split is not warned about here: it is a property of the data
+/// that no refresh can change, so each report labels it in-band beside the
+/// rows it qualifies (`SplitCoverage::partial_note`).
+fn warn_missing_agent_split(coverage: &SplitCoverage) {
+    if coverage.is_unavailable() {
         eprintln!(
             "{}",
             Style::stderr().warn(
@@ -1890,10 +1930,19 @@ fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()
     let main_out: i64 = skills.iter().map(|row| row.out_tokens).sum();
     let (sub_tokens, sub_agents) = store.subagent_totals()?;
     let agents = store.subagent_by_agent()?;
+    // How much of the total the rows actually account for: a store that kept
+    // totals for sessions whose transcripts were pruned before their runs were
+    // extracted has rows for only part of it, and the rows must not pass for
+    // the whole. It travels with the rows in every format.
+    let agent_split = SplitCoverage::new(
+        sub_tokens,
+        sub_agents,
+        agents.iter().map(|a| (a.runs, a.out_tokens)),
+    );
     // Ahead of the format branches: a machine consumer reading an empty `agents`
     // beside a nonzero total needs the reason as much as a human does, and it
     // goes to stderr precisely so it can be given to both.
-    warn_missing_agent_split(sub_tokens, agents.is_empty());
+    warn_missing_agent_split(&agent_split);
     if format == Format::Json {
         return emit_json(&serde_json::json!({
             "tokens": {
@@ -1901,6 +1950,7 @@ fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()
                 "sub_tokens": sub_tokens,
                 "sub_agents": sub_agents,
             },
+            "agent_split": agent_split,
             "agents": agents,
             "skills": skills,
         }));
@@ -1920,8 +1970,14 @@ fn usage(by: Option<&str>, format: Format, frozen: bool, db: &Path) -> Result<()
          A section with nothing to show is omitted.",
     );
     println!(
-        "tokens: main-thread skill output {main_out}, subagents {sub_tokens} ({sub_agents} agents)\n"
+        "tokens: main-thread skill output {main_out}, subagents {sub_tokens} ({sub_agents} agents)"
     );
+    // Stated between the total and the table, so the table below is read as
+    // the part it is.
+    if let Some(note) = agent_split.partial_note() {
+        println!("{note}");
+    }
+    println!();
 
     // The subagent figure is usually the larger one, so break it down by agent
     // type before the per-skill table: a spawn count alone cannot tell an
@@ -2683,6 +2739,100 @@ fn pad(text: &str, width: usize, align: Align) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn agent(name: &str, runs: i64, out_tokens: i64) -> optimize_mod::AgentCost {
+        optimize_mod::AgentCost {
+            agent: Some(name.to_string()),
+            runs,
+            out_tokens,
+        }
+    }
+
+    fn findings_with_agents(
+        sub_tokens: i64,
+        sub_agents: i64,
+        agents: Vec<optimize_mod::AgentCost>,
+    ) -> optimize_mod::Findings {
+        optimize_mod::Findings {
+            sub_tokens,
+            sub_agents,
+            agent_split: SplitCoverage::new(
+                sub_tokens,
+                sub_agents,
+                agents.iter().map(|a| (a.runs, a.out_tokens)),
+            ),
+            agents,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn doctor_calls_the_top_rows_most_of_the_output_only_when_they_are() {
+        let f = findings_with_agents(
+            1_000_000,
+            10,
+            vec![agent("a", 4, 700_000), agent("b", 6, 300_000)],
+        );
+        let lines = doctor_agent_lines(&f, "cclens usage");
+        assert_eq!(
+            lines,
+            vec![
+                "Most of that subagent output: a 700.0k (4 runs), b 300.0k (6 runs). \
+                 Full split: cclens usage"
+            ]
+        );
+    }
+
+    #[test]
+    fn doctor_does_not_call_a_minority_of_the_output_most_of_it() {
+        // A long tail: ten types at a tenth each, so the three shown cover 30%
+        // of the output, and "most" would be false even with a complete split.
+        let agents: Vec<_> = (0..10)
+            .map(|i| agent(&format!("t{i}"), 1, 100_000))
+            .collect();
+        let f = findings_with_agents(1_000_000, 10, agents);
+        let lines = doctor_agent_lines(&f, "cclens usage");
+        assert_eq!(
+            lines,
+            vec![
+                "The largest agent types: t0 100.0k (1 run), t1 100.0k (1 run), t2 100.0k \
+                 (1 run). Full split: cclens usage",
+                "… and 7 more agent type(s) not shown",
+            ]
+        );
+    }
+
+    #[test]
+    fn doctor_labels_a_partial_split_before_naming_its_agents() {
+        // The rows explain 12% of the total: saying "most of that output" here
+        // would blame the listed types for tokens no row accounts for.
+        let f = findings_with_agents(
+            3_093_466,
+            375,
+            vec![
+                agent("general-purpose", 11, 315_663),
+                agent("codex:codex-rescue", 14, 62_067),
+            ],
+        );
+        let lines = doctor_agent_lines(&f, "cclens usage");
+        assert_eq!(
+            lines,
+            vec![
+                "Only 377.7k of those tokens (25 of 375 runs) have a per-agent split — the \
+                 rest were analyzed before runs were extracted and their transcripts are gone.",
+                "Among the runs that have one: general-purpose 315.7k (11 runs), \
+                 codex:codex-rescue 62.1k (14 runs). Full split: cclens usage",
+            ]
+        );
+    }
+
+    #[test]
+    fn doctor_names_no_agents_when_the_split_is_unavailable() {
+        // The gap is reported on stderr with its refresh hint; there is
+        // nothing to list in-band.
+        let f = findings_with_agents(3_093_466, 375, vec![]);
+        assert!(doctor_agent_lines(&f, "cclens usage").is_empty());
+    }
 
     /// A path in the temp dir that no other test uses, removed on drop so a
     /// failure does not leak a file into the runner's temp dir.

--- a/src/core/optimize.rs
+++ b/src/core/optimize.rs
@@ -6,6 +6,7 @@
 
 use crate::core::friction::ErrorCategory;
 use crate::core::scope::ScopeFilter;
+use crate::core::subagent::SplitCoverage;
 
 /// The complete analysis the briefing renders — every view's detail as owned
 /// data, so the seeded session has the full picture in hand and need not re-run
@@ -20,6 +21,11 @@ pub struct Findings {
     /// The subagent total broken out per agent type, costliest first — which
     /// agent configurations that total actually paid for.
     pub agents: Vec<AgentCost>,
+    /// How much of `sub_tokens` / `sub_agents` the `agents` rows account for.
+    /// Sessions whose transcripts were pruned before their runs were extracted
+    /// keep their totals but never get rows, so the rows can be a partial
+    /// breakdown — and must be labeled as one wherever they are shown.
+    pub agent_split: SplitCoverage,
     /// Empirical always-on floor; 0 means unknown (section omitted).
     pub floor: i64,
     /// Global always-on config tokens (project config is per-project).
@@ -220,6 +226,12 @@ pub fn render_briefing(f: &Findings, filter: &ScopeFilter) -> String {
             "- Subagents: {} ({} agents)\n",
             f.sub_tokens, f.sub_agents
         ));
+        // Rows that fall short of the total are labeled before they are listed:
+        // read as the whole breakdown, they would pin the entire subagent bill
+        // on whichever types happened to be extracted.
+        if let Some(note) = f.agent_split.partial_note() {
+            out.push_str(&format!("  - {note}\n"));
+        }
         // Which agent types that total paid for — the split two agents with
         // similar spawn counts and very different output can only show here.
         for agent in &f.agents {
@@ -488,6 +500,7 @@ mod tests {
                     out_tokens: 300_000,
                 },
             ],
+            agent_split: SplitCoverage::new(1_800_000, 300, [(220, 1_500_000), (80, 300_000)]),
             floor: 35_000,
             config_tokens: 2_000,
             friction_global: vec![FrictionCat {
@@ -705,6 +718,31 @@ mod tests {
         // A run whose agent type was never recorded is shown as unknown, not
         // dropped — the per-agent rows must still sum to the total.
         assert!(brief.contains("  - (unknown): 300000 over 80 run(s)"));
+        // Rows that sum to the total need no coverage caveat.
+        assert!(!brief.contains("per-agent split covers"));
+    }
+
+    #[test]
+    fn briefing_labels_a_partial_agent_split_as_partial() {
+        // Sessions analyzed before runs were extracted keep their totals, but
+        // their pruned transcripts can never yield rows — so the rows shown
+        // explain only a fraction of the total, and the briefing must say so
+        // before the advisor blames the listed agent types for all of it.
+        let mut f = findings();
+        f.sub_tokens = 3_093_466;
+        f.sub_agents = 375;
+        f.agents = vec![AgentCost {
+            agent: Some("general-purpose".to_string()),
+            runs: 25,
+            out_tokens: 377_730,
+        }];
+        f.agent_split = SplitCoverage::new(3_093_466, 375, [(25, 377_730)]);
+        let brief = render_briefing(&f, &ScopeFilter::All);
+        assert!(brief.contains("- Subagents: 3093466 (375 agents)"));
+        assert!(brief.contains(
+            "  - per-agent split covers 377730 tokens over 25 run(s); the other \
+             2715736 tokens over 350 run(s) have no split"
+        ));
     }
 
     #[test]

--- a/src/core/subagent.rs
+++ b/src/core/subagent.rs
@@ -85,6 +85,86 @@ pub fn link_runs(runs: &mut [SubagentRun]) {
     }
 }
 
+/// How much of the session-level subagent total the per-agent rows account for.
+///
+/// The total and the rows come from different records and can disagree: a
+/// session's total survives as long as the store does, while its per-agent
+/// rows exist only if the transcript was still on disk when run extraction
+/// ran over it. Claude Code prunes transcripts on its own schedule, so a store
+/// analyzed before runs were extracted keeps totals whose rows can never be
+/// recovered — and the rows that *were* extracted would pass for the whole
+/// breakdown unless the gap is reported beside them. Every report that prints
+/// the rows carries this alongside so a partial split is labeled as one.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub struct SplitCoverage {
+    /// The session-level total: output tokens and run count.
+    pub total_tokens: i64,
+    pub total_runs: i64,
+    /// What the per-agent rows sum to.
+    pub known_tokens: i64,
+    pub known_runs: i64,
+    /// The part of the total no row accounts for — never negative.
+    pub missing_tokens: i64,
+    pub missing_runs: i64,
+}
+
+impl SplitCoverage {
+    /// Compare a session-level total against per-agent `rows` of
+    /// `(runs, out_tokens)`.
+    pub fn new(
+        total_tokens: i64,
+        total_runs: i64,
+        rows: impl IntoIterator<Item = (i64, i64)>,
+    ) -> Self {
+        let (known_runs, known_tokens) = rows
+            .into_iter()
+            .fold((0, 0), |(runs, tokens), (r, t)| (runs + r, tokens + t));
+        Self {
+            total_tokens,
+            total_runs,
+            known_tokens,
+            known_runs,
+            missing_tokens: (total_tokens - known_tokens).max(0),
+            missing_runs: (total_runs - known_runs).max(0),
+        }
+    }
+
+    /// A nonzero total with no rows behind it at all — the split was never
+    /// extracted, which a refresh may still fix. Either axis makes the total
+    /// nonzero: a run that wrote nothing is still a run.
+    pub fn is_unavailable(&self) -> bool {
+        (self.total_tokens > 0 || self.total_runs > 0)
+            && self.known_runs == 0
+            && self.known_tokens == 0
+    }
+
+    /// Rows exist but fall short of the total — the remainder belongs to
+    /// sessions whose runs are gone for good.
+    pub fn is_partial(&self) -> bool {
+        !self.is_unavailable() && (self.missing_tokens > 0 || self.missing_runs > 0)
+    }
+
+    /// Whether `tokens` (a subset of the rows) is more than half the total —
+    /// the bar for calling those rows "most of" the subagent output.
+    pub fn is_majority(&self, tokens: i64) -> bool {
+        self.total_tokens > 0 && tokens * 2 > self.total_tokens
+    }
+
+    /// The sentence a report prints beside a partial split, with exact
+    /// figures: what the rows cover, what they do not, and why the rest can
+    /// never be filled in. `None` when there is no gap to explain.
+    pub fn partial_note(&self) -> Option<String> {
+        self.is_partial().then(|| {
+            format!(
+                "per-agent split covers {} tokens over {} run(s); the other {} tokens over \
+                 {} run(s) have no split (analyzed before runs were extracted, transcripts \
+                 since pruned)",
+                self.known_tokens, self.known_runs, self.missing_tokens, self.missing_runs
+            )
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,5 +222,86 @@ mod tests {
         ];
         link_runs(&mut runs);
         assert!(runs.iter().all(|r| r.root_tool_use_id.is_none()));
+    }
+
+    #[test]
+    fn rows_summing_to_the_total_are_a_complete_split() {
+        let coverage = SplitCoverage::new(1_800_000, 300, [(220, 1_500_000), (80, 300_000)]);
+        assert_eq!(coverage.missing_tokens, 0);
+        assert_eq!(coverage.missing_runs, 0);
+        assert!(!coverage.is_partial());
+        assert!(!coverage.is_unavailable());
+    }
+
+    #[test]
+    fn rows_short_of_the_total_are_a_partial_split() {
+        // Sessions analyzed before per-run extraction keep their totals, but
+        // once Claude Code pruned their transcripts the runs can never be
+        // extracted — so the rows that were cover only a fraction.
+        let coverage = SplitCoverage::new(3_093_466, 375, [(11, 315_663), (14, 62_067)]);
+        assert_eq!(coverage.known_tokens, 377_730);
+        assert_eq!(coverage.known_runs, 25);
+        assert_eq!(coverage.missing_tokens, 2_715_736);
+        assert_eq!(coverage.missing_runs, 350);
+        assert!(coverage.is_partial());
+        assert!(!coverage.is_unavailable());
+    }
+
+    #[test]
+    fn no_rows_behind_a_nonzero_total_is_an_unavailable_split() {
+        let coverage = SplitCoverage::new(3_093_466, 375, []);
+        assert!(coverage.is_unavailable());
+        assert!(!coverage.is_partial());
+    }
+
+    #[test]
+    fn no_rows_behind_runs_that_wrote_nothing_is_still_an_unavailable_split() {
+        // A run that produced no output still counts as a run, so a total can
+        // be nonzero on the run axis alone — and rows are just as absent.
+        let coverage = SplitCoverage::new(0, 3, []);
+        assert!(coverage.is_unavailable());
+        assert!(!coverage.is_partial());
+    }
+
+    #[test]
+    fn no_rows_behind_a_zero_total_is_neither_partial_nor_unavailable() {
+        let coverage = SplitCoverage::new(0, 0, []);
+        assert!(!coverage.is_partial());
+        assert!(!coverage.is_unavailable());
+    }
+
+    #[test]
+    fn rows_exceeding_the_total_report_no_gap() {
+        // The gap is reported as what is missing, never as a negative figure.
+        let coverage = SplitCoverage::new(100, 1, [(2, 150)]);
+        assert_eq!(coverage.missing_tokens, 0);
+        assert_eq!(coverage.missing_runs, 0);
+        assert!(!coverage.is_partial());
+    }
+
+    #[test]
+    fn a_majority_is_more_than_half_of_the_total() {
+        let coverage = SplitCoverage::new(1_000, 10, [(10, 1_000)]);
+        assert!(coverage.is_majority(501));
+        assert!(!coverage.is_majority(500));
+        // A zero total has no majority to claim.
+        assert!(!SplitCoverage::new(0, 0, []).is_majority(0));
+    }
+
+    #[test]
+    fn a_partial_split_explains_its_gap_and_a_complete_one_says_nothing() {
+        let partial = SplitCoverage::new(3_093_466, 375, [(11, 315_663), (14, 62_067)]);
+        assert_eq!(
+            partial.partial_note().as_deref(),
+            Some(
+                "per-agent split covers 377730 tokens over 25 run(s); the other 2715736 tokens \
+                 over 350 run(s) have no split (analyzed before runs were extracted, \
+                 transcripts since pruned)"
+            )
+        );
+        assert_eq!(SplitCoverage::new(100, 1, [(1, 100)]).partial_note(), None);
+        // An unavailable split is a different message (a refresh may fix it),
+        // so it is not described as partial.
+        assert_eq!(SplitCoverage::new(100, 1, []).partial_note(), None);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -916,7 +916,11 @@ impl Store {
     /// is the agent that produced those tokens, and rolling it into its parent's
     /// type would credit the cost to an agent that only delegated. Runs whose
     /// type is unknown (no sidecar beside the transcript) group under `None`
-    /// rather than being dropped, so the rows still sum to the total.
+    /// rather than being dropped, so the rows sum to the total of every run
+    /// that was extracted. Sessions whose transcripts were pruned before their
+    /// runs could be extracted keep their totals but have no rows here; a
+    /// report reconciles the two with `core::subagent::SplitCoverage` rather
+    /// than presenting these rows as the whole breakdown.
     pub fn subagent_by_agent(&self) -> Result<Vec<AgentCost>> {
         let mut stmt = self.conn.prepare(
             "SELECT agent, COUNT(*), COALESCE(SUM(out_tokens), 0)


### PR DESCRIPTION
## Summary

- Add `core::subagent::SplitCoverage`, a pure type that reconciles the session-level subagent total (`sessions.sub_tokens` / `sub_agent_count`) against the per-agent rows (`subagent_runs`), keeping "no rows at all" (a refresh may fill them in) apart from "rows short of the total" (nothing can).
- `usage` prints the covered and uncovered figures between the total and the per-agent table, and adds an `agent_split` object to its JSON.
- `doctor` states the gap before naming any agent, and calls its top rows "most of that subagent output" only when they actually exceed half of the total; a long tail or a partial split gets wording that claims no more than the rows show.
- The optimize briefing carries the same note under its subagent line, so the seeded advisor does not pin the whole bill on whichever agent types survived extraction.
- The existing stderr warning is narrowed to the no-rows case; `docs/specs/cli.md` and `docs/specs/events.md` describe the partial-split contract and qualify the "rows sum exactly to the total" claim to the runs that could be extracted.

Closes #21

## Why

The store outlives its inputs by design: session totals survive after Claude Code prunes the transcripts they came from. Per-run extraction arrived later than session totals, so a store upgraded after pruning holds `subagent_runs` rows for only the sessions whose transcripts were still on disk. Nothing compared the two, and the only guard was "no rows at all", so a breakdown covering 12% of the subagent tokens was printed under the full total as if it explained it, with `doctor` calling it "most of that subagent output". Anyone acting on that would trim the wrong agent types, and the optimize advisor would propose fixes for a cost it could not actually see.

A partial split is a property of the data rather than a staleness a refresh could cure, so it is labeled in-band beside the rows it qualifies instead of reusing the existing "run `cclens analyze`" hint, which would send the user chasing rows that no longer exist.

## Test Plan

- [x] `cargo test` (232 passed), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`
- [x] Unit tests for `SplitCoverage` classification (complete / partial / unavailable on either axis / zero total / rows exceeding the total / majority bar / note text)
- [x] Unit tests for `doctor_agent_lines` (majority wording, long-tail wording, partial split stated first, unavailable split yields nothing) and for the briefing's partial note
- [x] Manually verified on a copy of a real store with most `subagent_runs` rows deleted: `usage` (text and JSON) and `doctor` label the gap; the unmodified store still reads "Most of that subagent output"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6g5F6QoiNG2AgL9R11DPV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now clearly identify when per-agent subagent totals provide only partial coverage of the overall session total.
  * The usage view displays covered and uncovered figures, including equivalent reconciliation details in JSON output.
  * Doctor and briefing reports include an in-line explanation when transcript pruning limits agent-level detail.

* **Documentation**
  * Updated CLI, event, and reporting documentation to describe partial split coverage and reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->