### PR TITLE
fix(transcript): count an assistant message once, not once per line

### DIFF
--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -132,7 +132,7 @@ Each metric is computed from the records strictly within the event/span.
 
 | Metric | Definition |
 | --- | --- |
-| `out_tokens` | Sum of `output_tokens` over the span's `assistant` records. |
+| `out_tokens` | Sum of `out_tokens` over the span's `assistant` records. Each record carries only the output it is the first to report, so the sum counts every API response once however many records it was written as; see "One message, several records" below. |
 | `ctx_growth` | **Compaction-safe** context consumption: the sum of *positive* differences in prompt size between consecutive `assistant` records. Decreases (compaction, cache eviction) are clipped to zero. |
 | `ctx_start` | Prompt size at the span's first `assistant` record — *where this skill ran*, not where the session began. See "The session-start context is its own event" below. |
 | `ctx_peak` | Maximum prompt size across the span's `assistant` records. |
@@ -141,6 +141,25 @@ Each metric is computed from the records strictly within the event/span.
 | `sub_agent_count` | Number of subagents attributed. |
 | `sub_tokens_estimated` | True when any attributed subagent was equally split (below). |
 | `model` | Representative model: the first `assistant` record whose model is **not** `<synthetic>`. NULL if none qualifies. |
+
+### One message, several records
+
+An `assistant` record is one transcript line, and one API response is written
+as several lines whose usage objects repeat or accumulate the same output
+(`session-format.md`). Summed naively, a response is charged once per line —
+and the factor varies by skill (how often the model thinks before it acts), so
+the error reorders skill rankings rather than merely inflating every figure.
+
+The core does not see this. The adapter reconciles the lines of a response as
+it parses, so each record's `out_tokens` is only the output that record is the
+first to report; the core sums records exactly as the definition above says
+and every response lands once. This keeps the layout knowledge where the
+format-isolation rule wants it, and it also settles the boundary case: when a
+span closes between two lines of one response (the response thought inside
+one skill and then invoked the next), the output is charged to the span that
+saw it first, never to both. Every line still yields a record, so
+`ctx_growth`, `ctx_start`, `ctx_peak` and `duration_sec` see the same
+timestamps and prompt sizes they always did.
 
 ### Why `ctx_growth`, not max-minus-start
 

--- a/docs/specs/session-format.md
+++ b/docs/specs/session-format.md
@@ -50,6 +50,22 @@ rest; unknown types are skipped.
 - `timestamp` — ISO-8601, millisecond precision, **UTC** (`Z` suffix, e.g.
   `2026-05-14T22:40:06.133Z`). Parsed to a UTC instant; timezone presentation
   happens later (`cli.md`).
+- `message.id` — the API response id. One response is written as **several
+  lines, one per content block** (`thinking`, `text`, `tool_use`), and every
+  line repeats `message.model` and carries a `message.usage`; the id is what
+  ties them back to one response. The lines take two shapes: on the main
+  thread each line's `output_tokens` is the response's final value repeated;
+  in a subagent transcript it is a running total that only grows, the last
+  line carrying the whole response. The adapter reconciles both at parse time
+  by emitting, per line, only the output not yet reported under that id — the
+  whole value on the first line and zero on a repeat, or each step of a
+  running total (`adapter::transcript::assistant_records`). That is the
+  per-id maximum, spread over the lines that first observed it, so the core
+  can sum records and count each response once (`events.md`). Keeping the
+  *first* line's value instead would under-count subagents badly, and
+  `stop_reason` is no substitute: every main-thread line carries one, and some
+  subagent responses carry it on no line. A line with no id reports its value
+  as is.
 - `message.model` — e.g. `claude-opus-4-7`. May be the sentinel `<synthetic>`
   for locally-generated turns; excluded when choosing an event's representative
   model (`events.md`).

--- a/src/adapter/transcript.rs
+++ b/src/adapter/transcript.rs
@@ -5,6 +5,7 @@
 //! deserializes defensively: only the needed fields, unknown fields ignored, a
 //! line that fails to parse or lacks a timestamp simply yields no records.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -17,14 +18,22 @@ use crate::core::span::{Record, RecordKind, Source};
 
 const SYNTHETIC_MODEL: &str = "<synthetic>";
 
-/// Parse one transcript's text into domain records, in file order. The current
-/// turn's prompt id is threaded forward and stamped onto agent spawns, whose own
-/// record does not carry it — that id is the join key to the subagent transcript.
+/// Parse one transcript's text into domain records, in file order. Two things
+/// are threaded across lines: the current turn's prompt id, stamped onto agent
+/// spawns whose own record does not carry it (the join key to the subagent
+/// transcript), and the output each API response has already reported, so a
+/// response written as several lines is charged once (`assistant_records`).
 pub fn parse_session(jsonl: &str) -> Vec<Record> {
     let mut current_prompt_id: Option<String> = None;
+    let mut reported_output: HashMap<String, u64> = HashMap::new();
     let mut records = Vec::new();
     for line in jsonl.lines() {
-        parse_line(line, &mut current_prompt_id, &mut records);
+        parse_line(
+            line,
+            &mut current_prompt_id,
+            &mut reported_output,
+            &mut records,
+        );
     }
     records
 }
@@ -51,6 +60,10 @@ struct Raw {
 
 #[derive(Deserialize)]
 struct RawMessage {
+    /// The API response id. Shared by every line the response was written as
+    /// (one per content block), which is what lets its usage be counted once
+    /// (`assistant_records`).
+    id: Option<String>,
     model: Option<String>,
     usage: Option<RawUsage>,
     content: Option<Value>,
@@ -64,7 +77,12 @@ struct RawUsage {
     output_tokens: Option<u64>,
 }
 
-fn parse_line(line: &str, current_prompt_id: &mut Option<String>, out: &mut Vec<Record>) {
+fn parse_line(
+    line: &str,
+    current_prompt_id: &mut Option<String>,
+    reported_output: &mut HashMap<String, u64>,
+    out: &mut Vec<Record>,
+) {
     let Ok(raw) = serde_json::from_str::<Raw>(line) else {
         return;
     };
@@ -76,7 +94,7 @@ fn parse_line(line: &str, current_prompt_id: &mut Option<String>, out: &mut Vec<
     };
 
     let mut records = match raw.kind.as_deref() {
-        Some("assistant") => assistant_records(ts, raw.message.as_ref()),
+        Some("assistant") => assistant_records(ts, raw.message.as_ref(), reported_output),
         Some("user") | Some("system") => prompt_or_invocation(ts, &raw, line),
         _ => Vec::new(),
     };
@@ -91,7 +109,24 @@ fn parse_line(line: &str, current_prompt_id: &mut Option<String>, out: &mut Vec<
 /// An assistant line yields its accumulated cost, plus a tool-path skill
 /// invocation when it called the Skill tool (emitted first so the span starts
 /// at the invocation and includes the calling turn's cost).
-fn assistant_records(ts: i64, message: Option<&RawMessage>) -> Vec<Record> {
+///
+/// A line is not an API response: Claude Code writes one line per content
+/// block of a response, every line carrying a usage object under the same
+/// `message.id`. On the main thread each line repeats the response's final
+/// usage; in a subagent transcript each carries the running total so far. The
+/// record's `out_tokens` is therefore the *increment* over what earlier lines
+/// of the same response already reported — the whole value on the first line
+/// and zero on a repeat, or each step of a running total — so the core can sum
+/// records and count every response exactly once, whichever shape the lines
+/// take and wherever a span boundary falls between them. Every line still
+/// yields a record, so timestamps and prompt sizes are seen as before. A line
+/// with no id has nothing to reconcile against and reports its value as is.
+/// See `docs/specs/session-format.md`.
+fn assistant_records(
+    ts: i64,
+    message: Option<&RawMessage>,
+    reported_output: &mut HashMap<String, u64>,
+) -> Vec<Record> {
     let Some(message) = message else {
         return Vec::new();
     };
@@ -116,11 +151,21 @@ fn assistant_records(ts: i64, message: Option<&RawMessage>) -> Vec<Record> {
         let prompt_size = usage.input_tokens.unwrap_or(0)
             + usage.cache_read_input_tokens.unwrap_or(0)
             + usage.cache_creation_input_tokens.unwrap_or(0);
+        let output = usage.output_tokens.unwrap_or(0);
+        let out_tokens = match &message.id {
+            Some(id) => {
+                let reported = reported_output.entry(id.clone()).or_insert(0);
+                let increment = output.saturating_sub(*reported);
+                *reported = (*reported).max(output);
+                increment
+            }
+            None => output,
+        };
         records.push(Record {
             timestamp_ms: ts,
             kind: RecordKind::Assistant {
                 prompt_size,
-                out_tokens: usage.output_tokens.unwrap_or(0),
+                out_tokens,
                 model: message
                     .model
                     .clone()
@@ -688,6 +733,93 @@ mod tests {
         assert_eq!(span.ctx_growth, 150); // (250 - 100), the closing prompt excluded
         assert_eq!(span.duration_sec, 3.0); // last in-window record at 3s, start at 0s
         assert_eq!(span.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn a_main_thread_message_split_across_lines_is_counted_once() {
+        // Claude Code writes one line per content block (thinking, text,
+        // tool_use) of an assistant message, and on the main thread every line
+        // repeats the same `message.usage`. Three lines are one API response.
+        let jsonl = concat!(
+            r#"{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","message":{"content":"<command-name>/git-commit</command-name>"}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"thinking","thinking":"..."}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.500Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"text","text":"..."}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"tool_use","name":"Bash","input":{"command":"true"}}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:04.000Z","message":{"id":"msg_b","model":"claude-opus-4-7","usage":{"input_tokens":0,"cache_read_input_tokens":250,"cache_creation_input_tokens":0,"output_tokens":60},"content":[{"type":"text","text":"done"}]}}"#,
+            "\n",
+            r#"{"type":"user","timestamp":"2026-01-01T00:00:05.000Z","message":{"content":"thanks"}}"#,
+        );
+
+        let spans = extract_spans(
+            &parse_session(jsonl),
+            crate::core::span::DEFAULT_IDLE_GAP_MS,
+        );
+
+        let span = &spans[0];
+        assert_eq!(span.out_tokens, 160); // msg_a once (100) + msg_b (60)
+        // The repeated lines still shape the other metrics exactly as before.
+        assert_eq!(span.ctx_growth, 150);
+        assert_eq!(span.duration_sec, 4.0);
+    }
+
+    #[test]
+    fn a_message_whose_lines_straddle_a_span_boundary_is_charged_once() {
+        // The response thinks inside the first span, then its tool_use line
+        // invokes a skill — which closes that span and opens the next one. The
+        // response's output must land in exactly one of the two.
+        let jsonl = concat!(
+            r#"{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","message":{"content":"<command-name>/git-commit</command-name>"}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"thinking","thinking":"..."}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"tool_use","name":"Skill","input":{"skill":"loop"}}]}}"#,
+            "\n",
+            r#"{"type":"user","timestamp":"2026-01-01T00:00:05.000Z","message":{"content":"thanks"}}"#,
+        );
+
+        let spans = extract_spans(
+            &parse_session(jsonl),
+            crate::core::span::DEFAULT_IDLE_GAP_MS,
+        );
+
+        assert_eq!(spans.len(), 2);
+        let total: u64 = spans.iter().map(|span| span.out_tokens).sum();
+        assert_eq!(total, 100);
+    }
+
+    #[test]
+    fn an_assistant_line_without_a_message_id_keeps_its_own_value() {
+        // Nothing ties id-less lines together, so each reports what it carries.
+        let jsonl = concat!(
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"model":"claude-opus-4-7","usage":{"output_tokens":40}}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","message":{"model":"claude-opus-4-7","usage":{"output_tokens":40}}}"#,
+        );
+
+        let total = crate::core::usage::output_tokens(&parse_session(jsonl));
+
+        assert_eq!(total, 80);
+    }
+
+    #[test]
+    fn a_subagent_message_split_across_lines_keeps_its_final_cumulative_value() {
+        // In a subagent transcript the per-line usage of a multi-line message is
+        // a running total, not a repeat: the last line carries the whole message.
+        let jsonl = concat!(
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":30},"content":[{"type":"thinking","thinking":"..."}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","message":{"id":"msg_a","model":"claude-opus-4-7","usage":{"input_tokens":10,"cache_read_input_tokens":90,"cache_creation_input_tokens":0,"output_tokens":100},"content":[{"type":"tool_use","name":"Bash","input":{"command":"true"}}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-01-01T00:00:04.000Z","message":{"id":"msg_b","model":"claude-opus-4-7","usage":{"input_tokens":0,"cache_read_input_tokens":250,"cache_creation_input_tokens":0,"output_tokens":20},"content":[{"type":"text","text":"done"}]}}"#,
+        );
+
+        let total = crate::core::usage::output_tokens(&parse_session(jsonl));
+
+        assert_eq!(total, 120); // msg_a's final 100 + msg_b's 20
     }
 
     #[test]

--- a/src/core/span.rs
+++ b/src/core/span.rs
@@ -26,6 +26,9 @@ pub enum RecordKind {
     Assistant {
         /// `input + cache_read + cache_creation` — the full prompt size.
         prompt_size: u64,
+        /// Output first reported by this record. The adapter reconciles the
+        /// several records one API response can yield, so summing this over
+        /// any run of records counts each response exactly once.
         out_tokens: u64,
         /// The model, or the `<synthetic>` sentinel.
         model: String,

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,7 +24,7 @@ const ANALYZER_META_KEY: &str = "analyzer_version";
 /// only way rows behind the incremental-ingest skip get rebuilt. It is not the
 /// crate version: a release that changes no analysis should not force everyone
 /// through a full re-analyze.
-const ANALYZER_VERSION: &str = "2";
+const ANALYZER_VERSION: &str = "3";
 
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS sessions (


### PR DESCRIPTION
## Summary

- Read `message.id` in the transcript adapter and emit, per assistant line, only the output not yet reported under that id — the whole value on the first line, zero on a repeat, or each step of a running total.
- The core keeps summing `Assistant` records; no new field or helper there. A span whose boundary falls between two lines of one message charges the output to the span that saw it first, never to both.
- Bump `ANALYZER_VERSION` so existing stores rebuild their inflated `events.out_tokens` on the next `analyze`.
- Fixtures now reproduce the real shape: a main-thread message split across three lines with identical usage, a message whose lines straddle a span boundary, id-less lines, and a subagent message with cumulative values.
- Specs updated in place: `events.md` (metric definition and the boundary case) and `session-format.md` (`message.id`, the two line shapes, why the adapter reconciles them).

## Why

Closes #22. Claude Code writes one transcript line per content block of an assistant message, and on the main thread every line repeats the same `message.usage`. cclens summed `output_tokens` per line, so a message written as three lines counted three times — roughly 2.6× overall in the reporter's store, and unevenly across skills, so rankings flipped rather than merely scaling. Only `out_tokens` was affected because the repeated lines carry an identical prompt size, which is why the context metrics looked fine and the tests passed.

Subagent transcripts have the same multi-line shape with a different meaning — a running total, the last line carrying the whole response — so the fix could not simply keep the first line's value. Per-id maximum is right for both shapes, and encoding it as per-line increments in the adapter keeps the layout knowledge inside the format-isolation boundary while letting the core stay a plain sum.

Verified read-only against a real project's transcripts: the `git-commit` spans' `out_tokens` total dropped from 21,994 to 10,626, while `ctx_growth`, `ctx_peak` and `duration_sec` totals were byte-identical before and after. An independent jq-based count over the same transcripts gave a 2.32× per-line/per-message factor, consistent with the report.

## Test Plan

- [x] `cargo test` — 223 passed, including the new fixtures
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] `cargo fmt --check`
- [x] Real-data comparison before/after on one project (read-only)
- [ ] Run `cclens analyze` on an existing store and confirm it re-ingests once (analyzer version 2 → 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qic4EoLWRsoVPG8hS9UBa9
